### PR TITLE
Ticket 3808: Command builder now populates mapping

### DIFF
--- a/lewis_emulators/danfysik/interfaces/dfkps_base.py
+++ b/lewis_emulators/danfysik/interfaces/dfkps_base.py
@@ -44,7 +44,7 @@ class CommonStreamInterface(object):
 
     @conditional_reply("comms_initialized")
     def set_current(self, value):
-        self.device.current = int(value)
+        self.device.current = value
 
     @conditional_reply("comms_initialized")
     def get_voltage(self):

--- a/lewis_emulators/fzj_dd_fermi_chopper/interfaces/stream_interface.py
+++ b/lewis_emulators/fzj_dd_fermi_chopper/interfaces/stream_interface.py
@@ -56,7 +56,7 @@ class FZJDDFCHStreamInterface(StreamInterface):
         if self._device.disconnected:
             return None
         if self._device.error_on_set_frequency is None:
-            self._device.frequency_setpoint = int(frequency) * self._device.frequency_reference
+            self._device.frequency_setpoint = frequency * self._device.frequency_reference
             reply = "{chopper_name}OK".format(chopper_name=chopper_name)
         else:
             reply = "ERROR;{}".format(self._device.error_on_set_frequency)
@@ -79,7 +79,7 @@ class FZJDDFCHStreamInterface(StreamInterface):
         if self._device.disconnected:
             return None
         if self._device.error_on_set_phase is None:
-            self._device.phase_setpoint = float(phase)
+            self._device.phase_setpoint = phase
             reply = "{chopper_name}OK".format(chopper_name=chopper_name)
         else:
             reply = "ERROR;{}".format(self._device.error_on_set_phase)

--- a/lewis_emulators/gemorc/interfaces/stream_interface.py
+++ b/lewis_emulators/gemorc/interfaces/stream_interface.py
@@ -93,7 +93,7 @@ class GemorcStreamInterface(StreamInterface):
         Args:
             offset: Datum offset in centi-degrees
         """
-        self.device.set_offset(int(offset))
+        self.device.set_offset(offset)
         return "OK"
 
     def set_acceleration(self, acceleration):
@@ -103,7 +103,7 @@ class GemorcStreamInterface(StreamInterface):
         Args:
             acceleration: Rate of acceleration in centi-degrees per second^2
         """
-        self.device.set_acceleration(int(acceleration))
+        self.device.set_acceleration(acceleration)
         return "OK"
 
     def set_speed(self, speed):
@@ -113,7 +113,7 @@ class GemorcStreamInterface(StreamInterface):
         Args:
             speed: Speed in centi-degrees per second
         """
-        self.device.set_speed(int(speed))
+        self.device.set_speed(speed)
         return "OK"
 
     def get_status(self):

--- a/lewis_emulators/hlg/interfaces/stream_interface.py
+++ b/lewis_emulators/hlg/interfaces/stream_interface.py
@@ -49,15 +49,14 @@ class HlgStreamInterface(StreamInterface):
         Returns: confirmation message
 
         """
-        verbosity_as_int = int(verbosity)
-        if verbosity_as_int not in [0, 1]:
-            raise AssertionError("Verbosity must be 0 or 1 was '{0}'".format(verbosity))
-        self._device.verbosity = verbosity_as_int
-        if verbosity_as_int == 0:
+        if verbosity not in [0, 1]:
+            raise AssertionError("Verbosity must be 0 or 1 was '{}'".format(verbosity))
+        self._device.verbosity = verbosity
+        if verbosity == 0:
             out_verbose = "Normal"
         else:
             out_verbose = "labVIEW"
-        return self._format_output("CV{0}".format(verbosity_as_int), "Verbose=", out_verbose)
+        return self._format_output("CV{0}".format(verbosity), "Verbose=", out_verbose)
 
     def set_prefix(self, prefix):
         """
@@ -68,11 +67,10 @@ class HlgStreamInterface(StreamInterface):
         Returns: confirmation message
 
         """
-        prefix_as_int = int(prefix)
-        if not 0 <= prefix_as_int < len(PREFIXES):
+        if not 0 <= prefix < len(PREFIXES):
             raise AssertionError("Prefix must be between 0 and {1} '{0}'".format(prefix, len(PREFIXES)))
-        self._device.prefix = prefix_as_int
-        return self._format_output("CP{0}".format(prefix_as_int), "Verbose=", prefix)
+        self._device.prefix = prefix
+        return self._format_output("CP{0}".format(prefix), "Verbose=", str(prefix))
 
     def get_level(self):
 

--- a/lewis_emulators/indfurn/interfaces/stream_interface.py
+++ b/lewis_emulators/indfurn/interfaces/stream_interface.py
@@ -99,28 +99,28 @@ class IndfurnStreamInterface(StreamInterface):
         return "<pidsp {:.2f}".format(self.device.setpoint)
 
     def set_setpoint(self, sp):
-        self.device.setpoint = float(sp)
+        self.device.setpoint = sp
         return "<ack"
 
     def get_psu_voltage(self):
         return "<powv {:.2f}".format(self.device.psu_voltage)
 
     def set_psu_voltage(self, voltage):
-        self.device.psu_voltage = float(voltage)
+        self.device.psu_voltage = voltage
         return "<ack"
 
     def get_psu_current(self):
         return "<powa {:.2f}".format(self.device.psu_current)
 
     def set_psu_current(self, current):
-        self.device.psu_current = float(current)
+        self.device.psu_current = current
         return "<ack"
 
     def get_output(self):
         return "<pidoutm {:.2f}".format(self.device.output)
 
     def set_output(self, output):
-        self.device.output = float(output)
+        self.device.output = output
         return "<ack"
 
     def get_thermocouple_temperature(self):
@@ -139,24 +139,24 @@ class IndfurnStreamInterface(StreamInterface):
         return "<pidtu {:.2f} {:.2f} {:.2f}".format(self.device.p, self.device.i, self.device.d)
 
     def set_pid_params(self, p, i, d):
-        self.device.p = float(p)
-        self.device.i = float(i)
-        self.device.d = float(d)
+        self.device.p = p
+        self.device.i = i
+        self.device.d = d
         return "<ack"
 
     def get_pid_limits(self):
         return "<PID out limit min max:  {:.2f} {:.2f}".format(self.device.pid_lower_limit, self.device.pid_upper_limit)
 
     def set_pid_limits(self, pid_lower_limit, pid_upper_limit):
-        self.device.pid_lower_limit = float(pid_lower_limit)
-        self.device.pid_upper_limit = float(pid_upper_limit)
+        self.device.pid_lower_limit = pid_lower_limit
+        self.device.pid_upper_limit = pid_upper_limit
         return "<ack"
 
     def get_sample_time(self):
         return "<pidst {:d}".format(self.device.sample_time)
 
     def set_sample_time(self, sample_time):
-        self.device.sample_time = int(sample_time)
+        self.device.sample_time = sample_time
         return "<ack"
 
     def get_psu_direction(self):

--- a/lewis_emulators/sp2xx/device.py
+++ b/lewis_emulators/sp2xx/device.py
@@ -199,8 +199,6 @@ class SimulatedSp2XX(StateMachineDevice):
         Returns:
             True if the diameter has been set and False otherwise.
         """
-        value = float(value)
-
         if value >= 100 or value < 0.01:
             return False
         else:

--- a/lewis_emulators/sp2xx/interfaces/stream_interface.py
+++ b/lewis_emulators/sp2xx/interfaces/stream_interface.py
@@ -59,7 +59,7 @@ class Sp2XXStreamInterface(StreamInterface):
             CmdBuilder(self.get_diameter).escape("dia?").eos().build(),
             CmdBuilder(self.set_diameter).escape("dia ").float().eos().build(),
             CmdBuilder(
-                self.set_volume_or_rate).arg("vol|rate").char().escape(" ").float().escape(" ").string().eos().build(),
+                self.set_volume_or_rate).arg("vol|rate").char().escape(" ").float(str).escape(" ").string().eos().build(),
             CmdBuilder(self.get_volume_or_rate).arg("vol|rate").char().escape("?").eos().build()
         }
 

--- a/lewis_emulators/tdk_lambda_genesys/interfaces/stream_interface.py
+++ b/lewis_emulators/tdk_lambda_genesys/interfaces/stream_interface.py
@@ -35,7 +35,7 @@ class TDKLambdaGenesysStreamInterface(StreamInterface):
     @conditional_reply("comms_initialized")
     def write_voltage(self, v):
         self._device.setpoint_voltage = v
-        return "VOLTAGE SET TO: " + v
+        return "VOLTAGE SET TO: {}".format(v)
 
     @conditional_reply("comms_initialized")
     def read_current(self):
@@ -48,7 +48,7 @@ class TDKLambdaGenesysStreamInterface(StreamInterface):
     @conditional_reply("comms_initialized")
     def write_current(self, c):
         self._device.setpoint_current = c
-        return "VOLTAGE SET TO: " + c
+        return "VOLTAGE SET TO: {}".format(c)
 
     @conditional_reply("comms_initialized")
     def read_power(self):
@@ -57,7 +57,7 @@ class TDKLambdaGenesysStreamInterface(StreamInterface):
     @conditional_reply("comms_initialized")
     def write_power(self, p):
         self._device.powerstate = p
-        return "POWER SET TO " + p
+        return "POWER SET TO {}".format(p)
 
     @conditional_reply("comms_initialized")
     def remote(self):

--- a/lewis_emulators/utils/command_builder.py
+++ b/lewis_emulators/utils/command_builder.py
@@ -111,21 +111,21 @@ class CmdBuilder(object):
             self.arg(".{{{}}}".format(length))
         return self
 
-    def float(self):
+    def float(self, mapping=float):
         """
         Add a float argument.
 
         :return: builder
         """
-        return self.arg(r"[+-]?\d+\.?\d*", float)
+        return self.arg(r"[+-]?\d+\.?\d*", mapping)
 
-    def digit(self):
+    def digit(self, mapping=int):
         """
         Add a single digit argument.
 
         :return: builder
         """
-        return self.arg(r"\d", int)
+        return self.arg(r"\d", mapping)
 
     def char(self, not_chars=None):
         """
@@ -141,13 +141,13 @@ class CmdBuilder(object):
             return self.arg(r".")
         return self.arg("[^{}]".format("".join(not_chars)))
 
-    def int(self):
+    def int(self, mapping=int):
         """
         Add an integer argument.
 
         :return: builder
         """
-        return self.arg(r"[+-]?\d+", int)
+        return self.arg(r"[+-]?\d+", mapping)
 
     def any(self):
         """

--- a/lewis_emulators/utils/command_builder.py
+++ b/lewis_emulators/utils/command_builder.py
@@ -40,6 +40,7 @@ class CmdBuilder(object):
         self._target_method = target_method
         self._arg_sep = arg_sep
         self._current_sep = ""
+        self.argument_mappings = []
         if ignore is None or ignore == "":
             self._ignore = ""
         else:
@@ -85,15 +86,17 @@ class CmdBuilder(object):
         self._add_to_regex(" " + wildchard, False)
         return self
 
-    def arg(self, arg_regex):
+    def arg(self, arg_regex, argument_mapping=str):
         """
         Add an argument to the command.
 
         :param arg_regex: regex for the argument (capture group will be added)
+        :param argument_mapping: the type mapping for the argument (default is str)
         :return: builder
         """
         self._add_to_regex(self._current_sep + "(" + arg_regex + ")", True)
         self._current_sep = self._arg_sep
+        self.argument_mappings.append(argument_mapping)
         return self
 
     def string(self, length=None):
@@ -105,7 +108,7 @@ class CmdBuilder(object):
         if length is None:
             self.arg(".+")
         else:
-            self.arg(".{{{}}}".format(length))
+            self.arg(".{{{}}}".format(length), str)
         return self
 
     def float(self):
@@ -114,7 +117,7 @@ class CmdBuilder(object):
 
         :return: builder
         """
-        return self.arg(r"[+-]?\d+\.?\d*")
+        return self.arg(r"[+-]?\d+\.?\d*", float)
 
     def digit(self):
         """
@@ -136,7 +139,7 @@ class CmdBuilder(object):
         """
         if not_chars is None:
             return self.arg(r".")
-        return self.arg("[^{}]".format("".join(not_chars)))
+        return self.arg("[^{}]".format("".join(not_chars)), str)
 
     def int(self):
         """
@@ -144,7 +147,7 @@ class CmdBuilder(object):
 
         :return: builder
         """
-        return self.arg(r"[+-]?\d+")
+        return self.arg(r"[+-]?\d+", int)
 
     def any(self):
         """
@@ -166,7 +169,7 @@ class CmdBuilder(object):
         :param kwargs: key word arguments to pass to Cmd constructor
         :return: Cmd object
         """
-        return Cmd(self._target_method, self._reg_ex, *args, **kwargs)
+        return Cmd(self._target_method, self._reg_ex, argument_mappings=self.argument_mappings, *args, **kwargs)
 
     def add_ascii_character(self, char_number):
         """

--- a/lewis_emulators/utils/command_builder.py
+++ b/lewis_emulators/utils/command_builder.py
@@ -108,7 +108,7 @@ class CmdBuilder(object):
         if length is None:
             self.arg(".+")
         else:
-            self.arg(".{{{}}}".format(length), str)
+            self.arg(".{{{}}}".format(length))
         return self
 
     def float(self):
@@ -125,7 +125,7 @@ class CmdBuilder(object):
 
         :return: builder
         """
-        return self.arg(r"\d")
+        return self.arg(r"\d", int)
 
     def char(self, not_chars=None):
         """
@@ -139,7 +139,7 @@ class CmdBuilder(object):
         """
         if not_chars is None:
             return self.arg(r".")
-        return self.arg("[^{}]".format("".join(not_chars)), str)
+        return self.arg("[^{}]".format("".join(not_chars)))
 
     def int(self):
         """


### PR DESCRIPTION
See https://github.com/ISISComputingGroup/IBEX/issues/3808.

To test run some of the affected IOC tests (such as sp2xx.DiameterTests) and confirm they still work despite removing the cast.