### PR TITLE
Ticket4091 rknps interlocks

### DIFF
--- a/lewis_emulators/rknps/device.py
+++ b/lewis_emulators/rknps/device.py
@@ -24,7 +24,7 @@ class PowerSupply(object):
         self.TRANS = True
         self.ILK = True
         self.DCOC = True
-        self.DCOLOAD = True
+        self.DCOL = True
         self.REGMOD = True
         self.PREREG = True
         self.PHAS = True
@@ -312,7 +312,7 @@ class SimulatedRknps(StateMachineDevice):
 
         self._currently_addressed_psu().DCOC = value
 
-    def get_DCOLOAD(self, ADDR=None):
+    def get_DCOL(self, ADDR=None):
         """
         Returns DC overload interlock
 
@@ -326,9 +326,9 @@ class SimulatedRknps(StateMachineDevice):
         if ADDR is not None:
             self.set_adr(ADDR)
 
-        return self._currently_addressed_psu().DCOLOAD
+        return self._currently_addressed_psu().DCOL
 
-    def set_DCOLOAD(self, value, ADDR):
+    def set_DCOL(self, value, ADDR):
         """
         Sets DC overload interlock
 
@@ -341,7 +341,7 @@ class SimulatedRknps(StateMachineDevice):
 
         self.set_adr(ADDR)
 
-        self._currently_addressed_psu().DCOLOAD = value
+        self._currently_addressed_psu().DCOL = value
 
     def get_REGMOD(self, ADDR=None):
         """

--- a/lewis_emulators/rknps/device.py
+++ b/lewis_emulators/rknps/device.py
@@ -19,6 +19,25 @@ class PowerSupply(object):
         self.power_on = True
         self.interlock_active = True
 
+        # Interlocks
+        self.POLNORM = True
+        self.REGTRANSF = True
+        self.TRANS = True
+        self.ILK = True
+        self.DCOC = True
+        self.DCOLOAD = True
+        self.REGMOD = True
+        self.PREREG = True
+        self.PHAS = True
+        self.MPSWATER = True
+        self.EARTHLEAK = True
+        self.THERMAL = True
+        self.MPSTEMP = True
+        self.DOOR = True
+        self.MAGWATER = True
+        self.MAGTEMP = True
+        self.MPSREADY = True
+
 
 ADDRESSES = ["001", "002", "003", "004"]
 
@@ -211,3 +230,386 @@ class SimulatedRknps(StateMachineDevice):
         """
         self.set_current(0)
         self.set_power(False)
+
+    @property
+    def interlock_TRANS(self):
+        """
+        Returns transistor fault interlock
+
+        Returns:
+            interlock_status: Boolean, the current status of the interlock
+        """
+
+        self.log.info('getting trans value {} PSU {}'.format(self._currently_addressed_psu().TRANS, self.get_adr()))
+
+        return self._currently_addressed_psu().TRANS
+
+#    @interlock_TRANS.setter
+#    def interlock_TRANS(self, value):
+#        """
+#        Sets transistor fault interlock
+#
+#        Args:
+#            interlock_status: Boolean, True for interlock triggered
+#        Returns:
+#            None
+#        """
+#
+#        self.log.info('setting trans to {} on {}'.format(value, self.get_adr()))
+#
+#        self._currently_addressed_psu().TRANS = value
+
+    def set_TRANS(self, value, ADDR):
+        """
+        Sets transistor fault interlock for PSU at address ADDR
+
+        Args:
+            value: Boolean, True for interlock triggered
+            ADDR: String, Address of PSU (e.g. 001)
+        Returns:
+            None
+        """
+
+        self.log.info('setting trans to {} on {}'.format(value, self.get_adr()))
+        self.set_adr(ADDR)
+
+        self._currently_addressed_psu().TRANS = value
+
+
+    @property
+    def interlock_DCOC(self):
+        """
+        Returns DC overcurrent interlock
+
+        Returns:
+            interlock_status: Boolean, the current status of the interlock
+        """
+
+        return self._currently_addressed_psu().DCOC
+
+    def set_DCOC(self, value, ADDR):
+        """
+        Sets DC overcurrent interlock
+
+        Args:
+            value: Boolean, True for interlock triggered
+            ADDR: String, Address of PSU (e.g. 001)
+        Returns:
+            None
+        """
+
+        self.set_adr(ADDR)
+
+        self._currently_addressed_psu().DCOC = value
+
+    @property
+    def interlock_DCOLOAD(self):
+        """
+        Returns DC overload interlock
+
+        Returns:
+            interlock_status: Boolean, the current status of the interlock
+        """
+
+        return self._currently_addressed_psu().DCOLOAD
+
+    def set_DCOLOAD(self, value, ADDR):
+        """
+        Sets DC overload interlock
+
+        Args:
+            value: Boolean, True for interlock triggered
+            ADDR: String, Address of PSU (e.g. 001)
+        Returns:
+            None
+        """
+
+        self.set_adr(ADDR)
+
+        self._currently_addressed_psu().DCOLOAD = value
+
+    @property
+    def interlock_REGMOD(self):
+        """
+        Returns Regulation mode failure interlock
+
+        Returns:
+            interlock_status: Boolean, the current status of the interlock
+        """
+
+        return self._currently_addressed_psu().REGMOD
+
+    def set_REGMOD(self, value, ADDR):
+        """
+        Sets Regulation mode failure interlock
+
+        Args:
+            value: Boolean, True for interlock triggered
+            ADDR: String, Address of PSU (e.g. 001)
+        Returns:
+            None
+        """
+
+        self.set_adr(ADDR)
+
+        self._currently_addressed_psu().REGMOD = value
+
+    @property
+    def interlock_PREREG(self):
+        """
+        Returns preregulator interlock
+
+        Returns:
+            interlock_status: Boolean, the current status of the interlock
+        """
+
+        return self._currently_addressed_psu().PREREG
+
+    def set_PREREG(self, value, ADDR):
+        """
+        Sets preregulator interlock
+
+        Args:
+            value: Boolean, True for interlock triggered
+            ADDR: String, Address of PSU (e.g. 001)
+        Returns:
+            None
+        """
+
+        self.set_adr(ADDR)
+
+        self._currently_addressed_psu().PREREG = value
+
+    @property
+    def interlock_PHAS(self):
+        """
+        Returns Phase failure interlock
+
+        Returns:
+            interlock_status: Boolean, the current status of the interlock
+        """
+
+        return self._currently_addressed_psu().PHAS
+
+    def set_PHAS(self, value, ADDR):
+        """
+        Sets phase failure interlock
+
+        Args:
+            value: Boolean, True for interlock triggered
+            ADDR: String, Address of PSU (e.g. 001)
+        Returns:
+            None
+        """
+
+        self.set_adr(ADDR)
+
+        self._currently_addressed_psu().PHAS = value
+
+    @property
+    def interlock_MPSWATER(self):
+        """
+        Returns MPS water flow interlock
+
+        Returns:
+            interlock_status: Boolean, the current status of the interlock
+        """
+
+        return self._currently_addressed_psu().MPSWATER
+
+    def set_MPSWATER(self, value, ADDR):
+        """
+        Sets MPS water flow interlock
+
+        Args:
+            value: Boolean, True for interlock triggered
+            ADDR: String, Address of PSU (e.g. 001)
+        Returns:
+            None
+        """
+
+        self.set_adr(ADDR)
+
+        self._currently_addressed_psu().MPSWATER = value
+
+    @property
+    def interlock_EARTHLEAK(self):
+        """
+        Returns earth leak interlock
+
+        Returns:
+            interlock_status: Boolean, the current status of the interlock
+        """
+
+        return self._currently_addressed_psu().EARTHLEAK
+
+    def set_EARTHLEAK(self, value, ADDR):
+        """
+        Sets earth leak interlock
+
+        Args:
+            value: Boolean, True for interlock triggered
+            ADDR: String, Address of PSU (e.g. 001)
+        Returns:
+            None
+        """
+
+        self.set_adr(ADDR)
+
+        self._currently_addressed_psu().EARTHLEAK = value
+
+    @property
+    def interlock_THERMAL(self):
+        """
+        Returns Thermal breaker interlock
+
+        Returns:
+            interlock_status: Boolean, the current status of the interlock
+        """
+
+        return self._currently_addressed_psu().THERMAL
+
+    def set_THERMAL(self, value, ADDR):
+        """
+        Sets Thermal breaker interlock
+
+        Args:
+            value: Boolean, True for interlock triggered
+            ADDR: String, Address of PSU (e.g. 001)
+        Returns:
+            None
+        """
+
+        self.set_adr(ADDR)
+
+        self._currently_addressed_psu().THERMAL = value
+
+    @property
+    def interlock_MPSTEMP(self):
+        """
+        Returns MPS over temperature interlock
+
+        Returns:
+            interlock_status: Boolean, the current status of the interlock
+        """
+
+        return self._currently_addressed_psu().MPSTEMP
+
+    def set_MPSTEMP(self, value, ADDR):
+        """
+        Sets MPS over temperature interlock
+
+        Args:
+            value: Boolean, True for interlock triggered
+            ADDR: String, Address of PSU (e.g. 001)
+        Returns:
+            None
+        """
+
+        self.set_adr(ADDR)
+
+        self._currently_addressed_psu().MPSTEMP = value
+
+    @property
+    def interlock_DOOR(self):
+        """
+        Returns panic button/door interlock
+
+        Returns:
+            interlock_status: Boolean, the current status of the interlock
+        """
+
+        return self._currently_addressed_psu().DOOR
+
+    def set_DOOR(self, value, ADDR):
+        """
+        Sets panic button/door interlock
+
+        Args:
+            value: Boolean, True for interlock triggered
+            ADDR: String, Address of PSU (e.g. 001)
+        Returns:
+            None
+        """
+
+        self.set_adr(ADDR)
+
+        self._currently_addressed_psu().DOOR = value
+
+    @property
+    def interlock_MAGWATER(self):
+        """
+        Returns manget water interlock
+
+        Returns:
+            interlock_status: Boolean, the current status of the interlock
+        """
+
+        return self._currently_addressed_psu().MAGWATER
+
+    def set_MAGWATER(self, value, ADDR):
+        """
+        Sets manget water interlock
+
+        Args:
+            value: Boolean, True for interlock triggered
+            ADDR: String, Address of PSU (e.g. 001)
+        Returns:
+            None
+        """
+
+        self.set_adr(ADDR)
+
+        self._currently_addressed_psu().MAGWATER = value
+
+    @property
+    def interlock_MAGTEMP(self):
+        """
+        Returns magnet temperature interlock
+
+        Returns:
+            interlock_status: Boolean, the current status of the interlock
+        """
+
+        return self._currently_addressed_psu().MAGTEMP
+
+    def set_MAGTEMP(self, value, ADDR):
+        """
+        Sets magnet temperature interlock
+
+        Args:
+            value: Boolean, True for interlock triggered
+            ADDR: String, Address of PSU (e.g. 001)
+        Returns:
+            None
+        """
+
+        self.set_adr(ADDR)
+
+        self._currently_addressed_psu().MAGTEMP = value
+
+    @property
+    def interlock_MPSREADY(self):
+        """
+        Returns MPS not ready interlock
+
+        Returns:
+            interlock_status: Boolean, the current status of the interlock
+        """
+
+        return self._currently_addressed_psu().MPSREADY
+
+    def set_MPSREADY(self, value, ADDR):
+        """
+        Sets MPS not ready interlock
+
+        Args:
+            value: Boolean, True for interlock triggered
+            ADDR: String, Address of PSU (e.g. 001)
+        Returns:
+            None
+        """
+
+        self.set_adr(ADDR)
+
+        self._currently_addressed_psu().MPSREADY = value

--- a/lewis_emulators/rknps/device.py
+++ b/lewis_emulators/rknps/device.py
@@ -21,7 +21,6 @@ class PowerSupply(object):
 
         # Interlocks
         self.POLNORM = True
-        self.REGTRANSF = True
         self.TRANS = True
         self.ILK = True
         self.DCOC = True
@@ -231,14 +230,19 @@ class SimulatedRknps(StateMachineDevice):
         self.set_current(0)
         self.set_power(False)
 
-    @property
-    def interlock_TRANS(self):
+    def get_TRANS(self, ADDR=None):
         """
         Returns transistor fault interlock
 
+        Args:
+            ADDR: String, optional.
+            The address of the PSU (e.g. 001). If None (default) the currently addressed PSU is used
         Returns:
             interlock_status: Boolean, the current status of the interlock
         """
+
+        if ADDR is not None:
+            self.set_adr(ADDR)
 
         interlock_status = self._currently_addressed_psu().TRANS
 
@@ -277,15 +281,19 @@ class SimulatedRknps(StateMachineDevice):
 
         self._currently_addressed_psu().TRANS = value
 
-
-    @property
-    def interlock_DCOC(self):
+    def get_DCOC(self, ADDR=None):
         """
         Returns DC overcurrent interlock
 
+        Args:
+            ADDR: String, optional.
+            The address of the PSU (e.g. 001). If None (default) the currently addressed PSU is used
         Returns:
             interlock_status: Boolean, the current status of the interlock
         """
+
+        if ADDR is not None:
+            self.set_adr(ADDR)        
 
         return self._currently_addressed_psu().DCOC
 
@@ -304,14 +312,19 @@ class SimulatedRknps(StateMachineDevice):
 
         self._currently_addressed_psu().DCOC = value
 
-    @property
-    def interlock_DCOLOAD(self):
+    def get_DCOLOAD(self, ADDR=None):
         """
         Returns DC overload interlock
 
+        Args:
+            ADDR: String, optional.
+            The address of the PSU (e.g. 001). If None (default) the currently addressed PSU is used
         Returns:
             interlock_status: Boolean, the current status of the interlock
         """
+
+        if ADDR is not None:
+            self.set_adr(ADDR)
 
         return self._currently_addressed_psu().DCOLOAD
 
@@ -330,14 +343,19 @@ class SimulatedRknps(StateMachineDevice):
 
         self._currently_addressed_psu().DCOLOAD = value
 
-    @property
-    def interlock_REGMOD(self):
+    def get_REGMOD(self, ADDR=None):
         """
         Returns Regulation mode failure interlock
 
+        Args:
+            ADDR: String, optional.
+            The address of the PSU (e.g. 001). If None (default) the currently addressed PSU is used
         Returns:
             interlock_status: Boolean, the current status of the interlock
         """
+
+        if ADDR is not None:
+            self.set_adr(ADDR)
 
         return self._currently_addressed_psu().REGMOD
 
@@ -356,14 +374,19 @@ class SimulatedRknps(StateMachineDevice):
 
         self._currently_addressed_psu().REGMOD = value
 
-    @property
-    def interlock_PREREG(self):
+    def get_PREREG(self, ADDR=None):
         """
         Returns preregulator interlock
 
+        Args:
+            ADDR: String, optional.
+            The address of the PSU (e.g. 001). If None (default) the currently addressed PSU is used
         Returns:
             interlock_status: Boolean, the current status of the interlock
         """
+
+        if ADDR is not None:
+            self.set_adr(ADDR)
 
         return self._currently_addressed_psu().PREREG
 
@@ -382,14 +405,19 @@ class SimulatedRknps(StateMachineDevice):
 
         self._currently_addressed_psu().PREREG = value
 
-    @property
-    def interlock_PHAS(self):
+    def get_PHAS(self, ADDR=None):
         """
         Returns Phase failure interlock
 
+        Args:
+            ADDR: String, optional.
+            The address of the PSU (e.g. 001). If None (default) the currently addressed PSU is used
         Returns:
             interlock_status: Boolean, the current status of the interlock
         """
+
+        if ADDR is not None:
+            self.set_adr(ADDR)
 
         return self._currently_addressed_psu().PHAS
 
@@ -408,14 +436,19 @@ class SimulatedRknps(StateMachineDevice):
 
         self._currently_addressed_psu().PHAS = value
 
-    @property
-    def interlock_MPSWATER(self):
+    def get_MPSWATER(self, ADDR=None):
         """
         Returns MPS water flow interlock
 
+        Args:
+            ADDR: String, optional.
+            The address of the PSU (e.g. 001). If None (default) the currently addressed PSU is used
         Returns:
             interlock_status: Boolean, the current status of the interlock
         """
+
+        if ADDR is not None:
+            self.set_adr(ADDR)
 
         return self._currently_addressed_psu().MPSWATER
 
@@ -434,14 +467,19 @@ class SimulatedRknps(StateMachineDevice):
 
         self._currently_addressed_psu().MPSWATER = value
 
-    @property
-    def interlock_EARTHLEAK(self):
+    def get_EARTHLEAK(self, ADDR=None):
         """
         Returns earth leak interlock
 
+        Args:
+            ADDR: String, optional.
+            The address of the PSU (e.g. 001). If None (default) the currently addressed PSU is used
         Returns:
             interlock_status: Boolean, the current status of the interlock
         """
+
+        if ADDR is not None:
+            self.set_adr(ADDR)
 
         return self._currently_addressed_psu().EARTHLEAK
 
@@ -460,14 +498,19 @@ class SimulatedRknps(StateMachineDevice):
 
         self._currently_addressed_psu().EARTHLEAK = value
 
-    @property
-    def interlock_THERMAL(self):
+    def get_THERMAL(self, ADDR=None):
         """
         Returns Thermal breaker interlock
 
+        Args:
+            ADDR: String, optional.
+            The address of the PSU (e.g. 001). If None (default) the currently addressed PSU is used
         Returns:
             interlock_status: Boolean, the current status of the interlock
         """
+
+        if ADDR is not None:
+            self.set_adr(ADDR)
 
         return self._currently_addressed_psu().THERMAL
 
@@ -486,14 +529,19 @@ class SimulatedRknps(StateMachineDevice):
 
         self._currently_addressed_psu().THERMAL = value
 
-    @property
-    def interlock_MPSTEMP(self):
+    def get_MPSTEMP(self, ADDR=None):
         """
         Returns MPS over temperature interlock
 
+        Args:
+            ADDR: String, optional.
+            The address of the PSU (e.g. 001). If None (default) the currently addressed PSU is used
         Returns:
             interlock_status: Boolean, the current status of the interlock
         """
+
+        if ADDR is not None:
+            self.set_adr(ADDR)
 
         return self._currently_addressed_psu().MPSTEMP
 
@@ -512,14 +560,19 @@ class SimulatedRknps(StateMachineDevice):
 
         self._currently_addressed_psu().MPSTEMP = value
 
-    @property
-    def interlock_DOOR(self):
+    def get_DOOR(self, ADDR=None):
         """
         Returns panic button/door interlock
 
+        Args:
+            ADDR: String, optional.
+            The address of the PSU (e.g. 001). If None (default) the currently addressed PSU is used
         Returns:
             interlock_status: Boolean, the current status of the interlock
         """
+
+        if ADDR is not None:
+            self.set_adr(ADDR)
 
         return self._currently_addressed_psu().DOOR
 
@@ -538,14 +591,19 @@ class SimulatedRknps(StateMachineDevice):
 
         self._currently_addressed_psu().DOOR = value
 
-    @property
-    def interlock_MAGWATER(self):
+    def get_MAGWATER(self, ADDR=None):
         """
         Returns manget water interlock
 
+        Args:
+            ADDR: String, optional.
+            The address of the PSU (e.g. 001). If None (default) the currently addressed PSU is used
         Returns:
             interlock_status: Boolean, the current status of the interlock
         """
+
+        if ADDR is not None:
+            self.set_adr(ADDR)
 
         return self._currently_addressed_psu().MAGWATER
 
@@ -564,14 +622,19 @@ class SimulatedRknps(StateMachineDevice):
 
         self._currently_addressed_psu().MAGWATER = value
 
-    @property
-    def interlock_MAGTEMP(self):
+    def get_MAGTEMP(self, ADDR=None):
         """
         Returns magnet temperature interlock
 
+        Args:
+            ADDR: String, optional.
+            The address of the PSU (e.g. 001). If None (default) the currently addressed PSU is used
         Returns:
             interlock_status: Boolean, the current status of the interlock
         """
+
+        if ADDR is not None:
+            self.set_adr(ADDR)
 
         return self._currently_addressed_psu().MAGTEMP
 
@@ -590,14 +653,19 @@ class SimulatedRknps(StateMachineDevice):
 
         self._currently_addressed_psu().MAGTEMP = value
 
-    @property
-    def interlock_MPSREADY(self):
+    def get_MPSREADY(self, ADDR=None):
         """
         Returns MPS not ready interlock
 
+        Args:
+            ADDR: String, optional.
+            The address of the PSU (e.g. 001). If None (default) the currently addressed PSU is used
         Returns:
             interlock_status: Boolean, the current status of the interlock
         """
+
+        if ADDR is not None:
+            self.set_adr(ADDR)
 
         return self._currently_addressed_psu().MPSREADY
 

--- a/lewis_emulators/rknps/device.py
+++ b/lewis_emulators/rknps/device.py
@@ -240,9 +240,11 @@ class SimulatedRknps(StateMachineDevice):
             interlock_status: Boolean, the current status of the interlock
         """
 
-        self.log.info('getting trans value {} PSU {}'.format(self._currently_addressed_psu().TRANS, self.get_adr()))
+        interlock_status = self._currently_addressed_psu().TRANS
 
-        return self._currently_addressed_psu().TRANS
+        self.log.info('getting trans value {} PSU {}'.format(interlock_status, self.get_adr()))
+
+        return interlock_status
 
 #    @interlock_TRANS.setter
 #    def interlock_TRANS(self, value):

--- a/lewis_emulators/rknps/device.py
+++ b/lewis_emulators/rknps/device.py
@@ -250,21 +250,6 @@ class SimulatedRknps(StateMachineDevice):
 
         return interlock_status
 
-#    @interlock_TRANS.setter
-#    def interlock_TRANS(self, value):
-#        """
-#        Sets transistor fault interlock
-#
-#        Args:
-#            interlock_status: Boolean, True for interlock triggered
-#        Returns:
-#            None
-#        """
-#
-#        self.log.info('setting trans to {} on {}'.format(value, self.get_adr()))
-#
-#        self._currently_addressed_psu().TRANS = value
-
     def set_TRANS(self, value, ADDR):
         """
         Sets transistor fault interlock for PSU at address ADDR

--- a/lewis_emulators/rknps/interfaces/stream_interface.py
+++ b/lewis_emulators/rknps/interfaces/stream_interface.py
@@ -6,6 +6,8 @@ from lewis_emulators.utils.replies import conditional_reply
 
 if_connected = conditional_reply("connected")
 
+ILK_STRING = {True: "!", False: "."}
+
 @has_log
 class RknpsStreamInterface(StreamInterface):
     """
@@ -138,7 +140,7 @@ class RknpsStreamInterface(StreamInterface):
         else:
             raise ValueError("Invalid argument to set_polarity")
 
-    @if_connected
+    #@if_connected
     def get_status(self):
         """
         Get the status of the device.
@@ -146,8 +148,42 @@ class RknpsStreamInterface(StreamInterface):
         Returns: A character string for the status.
         """
         power = "." if self._device.is_power_on() else "!"
+        #self.log.info(power)
+        #self.log.info(self._device.is_power_on())
         interlock = "!" if self._device.is_interlock_active() else "."
-        return "{}........{}..............".format(power, interlock)
+
+        device = self._device
+
+        self.log.info('trans string = '+ILK_STRING[device.interlock_TRANS])
+
+        #self.log.info("{}........{}..............".format(power, interlock))
+        status = ("{POWER}.!.....{TRANS}{ILK}{DCOC}{DCOLOAD}{REGMOD}{PREREG}{PHAS}"
+                  "{MPSWATER}{EARTHLEAK}{THERMAL}{MPSTEMP}{DOOR}{MAGWATER}{MAGTEMP}"
+                  "{MPSREADY}.").format(
+                                        # ILK_STRING[device.POLNORM_OK],
+                                        # ILK_STRING[device.REGTRANSF_OK],
+                                        POWER=ILK_STRING[device.is_power_on()],
+                                        TRANS=ILK_STRING[device.interlock_TRANS],
+                                        ILK=ILK_STRING[False],
+                                        DCOC=ILK_STRING[device.interlock_DCOC],
+                                        DCOLOAD=ILK_STRING[device.interlock_DCOLOAD],
+                                        REGMOD=ILK_STRING[device.interlock_REGMOD],
+                                        PREREG=ILK_STRING[device.interlock_PREREG],
+                                        PHAS=ILK_STRING[device.interlock_PHAS],
+                                        MPSWATER=ILK_STRING[device.interlock_MPSWATER],
+                                        EARTHLEAK=ILK_STRING[device.interlock_EARTHLEAK],
+                                        THERMAL=ILK_STRING[device.interlock_THERMAL],
+                                        MPSTEMP=ILK_STRING[device.interlock_MPSTEMP],
+                                        DOOR=ILK_STRING[device.interlock_DOOR],
+                                        MAGWATER=ILK_STRING[device.interlock_MAGWATER],
+                                        MAGTEMP=ILK_STRING[device.interlock_MAGTEMP],
+                                        MPSREADY=ILK_STRING[device.interlock_MPSREADY]
+                                        )
+
+        # return "{}........{}..............".format(power, interlock)
+        # status = "!........!.............."
+        self.log.info(status)
+        return status
 
     @if_connected
     def set_power(self, power):

--- a/lewis_emulators/rknps/interfaces/stream_interface.py
+++ b/lewis_emulators/rknps/interfaces/stream_interface.py
@@ -150,14 +150,7 @@ class RknpsStreamInterface(StreamInterface):
 
         Returns: A character string for the status.
         """
-        power = "." if self._device.is_power_on() else "!"
-        #self.log.info(power)
-        #self.log.info(self._device.is_power_on())
-        interlock = "!" if self._device.is_interlock_active() else "."
-
         device = self._device
-
-        self.log.info('trans string = '+ILK_STRING[device.get_TRANS()])
 
         status = ("{POWER}.!.....{TRANS}{ILK}{DCOC}{DCOLOAD}{REGMOD}{PREREG}{PHAS}"
                   "{MPSWATER}{EARTHLEAK}{THERMAL}{MPSTEMP}{DOOR}{MAGWATER}{MAGTEMP}"
@@ -180,9 +173,6 @@ class RknpsStreamInterface(StreamInterface):
                                         MPSREADY=ILK_STRING[device.get_MPSREADY()]
                                         )
 
-        # return "{}........{}..............".format(power, interlock)
-        # status = "!........!.............."
-        self.log.info(status)
         return status
 
     @if_connected

--- a/lewis_emulators/rknps/interfaces/stream_interface.py
+++ b/lewis_emulators/rknps/interfaces/stream_interface.py
@@ -7,6 +7,7 @@ from lewis_emulators.utils.replies import conditional_reply
 if_connected = conditional_reply("connected")
 
 ILK_STRING = {True: "!", False: "."}
+PWR_STRING = {True: ".", False: "!"}
 
 @has_log
 class RknpsStreamInterface(StreamInterface):
@@ -140,7 +141,7 @@ class RknpsStreamInterface(StreamInterface):
         else:
             raise ValueError("Invalid argument to set_polarity")
 
-    #@if_connected
+    @if_connected
     def get_status(self):
         """
         Get the status of the device.
@@ -154,7 +155,7 @@ class RknpsStreamInterface(StreamInterface):
 
         device = self._device
 
-        self.log.info('trans string = '+ILK_STRING[device.interlock_TRANS])
+        self.log.info('trans string = '+ILK_STRING[device.get_TRANS()])
 
         #self.log.info("{}........{}..............".format(power, interlock))
         status = ("{POWER}.!.....{TRANS}{ILK}{DCOC}{DCOLOAD}{REGMOD}{PREREG}{PHAS}"
@@ -162,22 +163,22 @@ class RknpsStreamInterface(StreamInterface):
                   "{MPSREADY}.").format(
                                         # ILK_STRING[device.POLNORM_OK],
                                         # ILK_STRING[device.REGTRANSF_OK],
-                                        POWER=ILK_STRING[device.is_power_on()],
-                                        TRANS=ILK_STRING[device.interlock_TRANS],
-                                        ILK=ILK_STRING[False],
-                                        DCOC=ILK_STRING[device.interlock_DCOC],
-                                        DCOLOAD=ILK_STRING[device.interlock_DCOLOAD],
-                                        REGMOD=ILK_STRING[device.interlock_REGMOD],
-                                        PREREG=ILK_STRING[device.interlock_PREREG],
-                                        PHAS=ILK_STRING[device.interlock_PHAS],
-                                        MPSWATER=ILK_STRING[device.interlock_MPSWATER],
-                                        EARTHLEAK=ILK_STRING[device.interlock_EARTHLEAK],
-                                        THERMAL=ILK_STRING[device.interlock_THERMAL],
-                                        MPSTEMP=ILK_STRING[device.interlock_MPSTEMP],
-                                        DOOR=ILK_STRING[device.interlock_DOOR],
-                                        MAGWATER=ILK_STRING[device.interlock_MAGWATER],
-                                        MAGTEMP=ILK_STRING[device.interlock_MAGTEMP],
-                                        MPSREADY=ILK_STRING[device.interlock_MPSREADY]
+                                        POWER=PWR_STRING[device.is_power_on()],
+                                        TRANS=ILK_STRING[device.get_TRANS()],
+                                        ILK=ILK_STRING[device.is_interlock_active()],
+                                        DCOC=ILK_STRING[device.get_DCOC()],
+                                        DCOLOAD=ILK_STRING[device.get_DCOLOAD()],
+                                        REGMOD=ILK_STRING[device.get_REGMOD()],
+                                        PREREG=ILK_STRING[device.get_PREREG()],
+                                        PHAS=ILK_STRING[device.get_PHAS()],
+                                        MPSWATER=ILK_STRING[device.get_MPSWATER()],
+                                        EARTHLEAK=ILK_STRING[device.get_EARTHLEAK()],
+                                        THERMAL=ILK_STRING[device.get_THERMAL()],
+                                        MPSTEMP=ILK_STRING[device.get_MPSTEMP()],
+                                        DOOR=ILK_STRING[device.get_DOOR()],
+                                        MAGWATER=ILK_STRING[device.get_MAGWATER()],
+                                        MAGTEMP=ILK_STRING[device.get_MAGTEMP()],
+                                        MPSREADY=ILK_STRING[device.get_MPSREADY()]
                                         )
 
         # return "{}........{}..............".format(power, interlock)

--- a/lewis_emulators/rknps/interfaces/stream_interface.py
+++ b/lewis_emulators/rknps/interfaces/stream_interface.py
@@ -141,6 +141,8 @@ class RknpsStreamInterface(StreamInterface):
         else:
             raise ValueError("Invalid argument to set_polarity")
 
+        return pol
+
     @if_connected
     def get_status(self):
         """
@@ -157,17 +159,14 @@ class RknpsStreamInterface(StreamInterface):
 
         self.log.info('trans string = '+ILK_STRING[device.get_TRANS()])
 
-        #self.log.info("{}........{}..............".format(power, interlock))
         status = ("{POWER}.!.....{TRANS}{ILK}{DCOC}{DCOLOAD}{REGMOD}{PREREG}{PHAS}"
                   "{MPSWATER}{EARTHLEAK}{THERMAL}{MPSTEMP}{DOOR}{MAGWATER}{MAGTEMP}"
                   "{MPSREADY}.").format(
-                                        # ILK_STRING[device.POLNORM_OK],
-                                        # ILK_STRING[device.REGTRANSF_OK],
                                         POWER=PWR_STRING[device.is_power_on()],
                                         TRANS=ILK_STRING[device.get_TRANS()],
                                         ILK=ILK_STRING[device.is_interlock_active()],
                                         DCOC=ILK_STRING[device.get_DCOC()],
-                                        DCOLOAD=ILK_STRING[device.get_DCOLOAD()],
+                                        DCOLOAD=ILK_STRING[device.get_DCOL()],
                                         REGMOD=ILK_STRING[device.get_REGMOD()],
                                         PREREG=ILK_STRING[device.get_PREREG()],
                                         PHAS=ILK_STRING[device.get_PHAS()],
@@ -196,8 +195,10 @@ class RknpsStreamInterface(StreamInterface):
         """
         if power == "N":
             self._device.set_power(True)
+            self.log.info('PWR ON')
         elif power == "F":
             self._device.set_power(False)
+            self.log.info('PWR OFF')
         else:
             raise ValueError("Invalid argument to set_power")
 


### PR DESCRIPTION
### Description of work

Adds setters/getters for individual PSU interlocks. Status string now built from interlock attributes

### To test

https://github.com/ISISComputingGroup/IBEX/issues/4091

### Acceptance criteria

- [ ] Each PSU can has all required interlocks
- [ ] Interlocks can be individually addressed, changed and read from

---
