### PR TITLE
Ticket3720 dfkps 8500

### DIFF
--- a/lewis_emulators/danfysik/device.py
+++ b/lewis_emulators/danfysik/device.py
@@ -38,6 +38,9 @@ class SimulatedDanfysik(StateMachineDevice):
         # Use a list of active interlocks because each danfysik has different sets of interlocks which can be enabled.
         self.active_interlocks = []
 
+        self.currently_addressed_psu = 0
+        self.address = 75
+
     def enable_interlock(self, name):
         """
         Adds an interlock to the list of enabled interlock
@@ -55,6 +58,25 @@ class SimulatedDanfysik(StateMachineDevice):
         """
         if name in self.active_interlocks:
             self.active_interlocks.remove(name)
+
+    def set_address(self, value):
+        """
+        Changes the currently addressed PSU
+
+        Args:
+            value: int, the address to set the PSU to.
+        """
+
+        self.currently_addressed_psu = value
+
+        self.log.info("Address set to, {}".format(value))
+
+        if self.address != self.currently_addressed_psu:
+            self.comms_initialized = False
+            self.log.info("Device down")
+        else:
+            self.comms_initialized = True
+            self.log.info("Device up")
 
     def reset(self):
         """

--- a/lewis_emulators/danfysik/interfaces/dfkps_8500.py
+++ b/lewis_emulators/danfysik/interfaces/dfkps_8500.py
@@ -1,0 +1,89 @@
+"""
+Stream device for danfysik 8500
+"""
+from lewis.adapters.stream import StreamInterface
+from lewis.core.logging import has_log
+
+from lewis_emulators.utils.command_builder import CmdBuilder
+from lewis_emulators.utils.replies import conditional_reply
+from .dfkps_base import CommonStreamInterface
+
+__all__ = ["Danfysik8500StreamInterface"]
+
+
+@has_log
+class Danfysik8500StreamInterface(CommonStreamInterface, StreamInterface):
+    """
+    Stream interface for a Danfysik model 8500.
+    """
+
+    in_terminator = "\r\n"
+    out_terminator = "\r\n"
+
+    protocol = 'model8500'
+
+    # This is the address of the LOQ danfysik 8500
+    PSU_ADDRESS = 75
+
+    commands = CommonStreamInterface.commands + [
+        CmdBuilder("set_current").escape("DA 0 ").int().eos().build(),
+        CmdBuilder("get_current").escape("AD 8").eos().build(),
+        CmdBuilder("set_address").escape("ADR ").int().eos().build(),
+        CmdBuilder("get_address").escape("ADR").eos().build(),
+        CmdBuilder("init_comms").escape("REM").build(),
+    ]
+
+    @conditional_reply("device_available")
+    @conditional_reply("comms_initialized")
+    def get_status(self):
+        """
+        Respond to the get_status command (S1)
+        """
+        def bit(condition):
+            return "!" if condition else "."
+
+        def ilk(name):
+            return bit(name in self.device.active_interlocks)
+
+        response = "{power_off}{pol_normal}{pol_reversed}{reg_transformer}{dac16}{dac17}{is_percent}{spare}"\
+                   "{transistor_fault}{sum_interlock}{dc_overcurrent}{dc_overload}{reg_mod_fail}{prereg_fail}" \
+                   "{phase_fail}{mps_waterflow_fail}{earth_leak_fail}{thermal_fail}{mps_overtemperature}" \
+                   "{door_switch}{mag_waterflow_fail}{mag_overtemp}{mps_not_ready}{spare}".format(
+                        spare=bit(False),
+                        power_off=bit(not self.device.power),
+                        pol_normal=bit(not self.device.negative_polarity),
+                        pol_reversed=bit(self.device.negative_polarity),
+                        reg_transformer=bit(False),
+                        dac16=bit(False),
+                        dac17=bit(False),
+                        is_percent=bit(False),
+                        transistor_fault=ilk("transistor_fault"),
+                        sum_interlock=bit(len(self.device.active_interlocks) > 0),
+                        dc_overcurrent=ilk("dc_overcurrent"),
+                        dc_overload=ilk("dc_overload"),
+                        reg_mod_fail=ilk("reg_mod_fail"),
+                        prereg_fail=ilk("prereg_fail"),
+                        phase_fail=ilk("phase_fail"),
+                        mps_waterflow_fail=ilk("mps_waterflow_fail"),
+                        earth_leak_fail=ilk("earth_leak_fail"),
+                        thermal_fail=ilk("thermal_fail"),
+                        mps_overtemperature=ilk("mps_overtemperature"),
+                        door_switch=ilk("door_switch"),
+                        mag_waterflow_fail=ilk("mag_waterflow_fail"),
+                        mag_overtemp=ilk("mag_overtemp"),
+                        mps_not_ready=bit(not self.device.power),
+                    )
+
+        assert len(response) == 24, "length should have been 24 but was {}".format(len(response))
+
+        self.log.info(self.device.device_available)
+
+        return response
+
+    def set_address(self, value):
+        self.device.set_address(value)
+        self.log.info(repr(self.device))
+
+    @conditional_reply("comms_initialized")
+    def get_address(self):
+        return "{:03d}".format(self.address)

--- a/lewis_emulators/danfysik/interfaces/dfkps_8500.py
+++ b/lewis_emulators/danfysik/interfaces/dfkps_8500.py
@@ -32,6 +32,7 @@ class Danfysik8500StreamInterface(CommonStreamInterface, StreamInterface):
         CmdBuilder("get_address").escape("ADR").eos().build(),
         CmdBuilder("init_comms").escape("REM").eos().build(),
         CmdBuilder("init_comms").escape("UNLOCK").eos().build(),
+        CmdBuilder("set_polarity").escape("PO ").arg("\+|\-").eos().build(),
     ]
 
     @conditional_reply("device_available")

--- a/lewis_emulators/danfysik/interfaces/dfkps_8500.py
+++ b/lewis_emulators/danfysik/interfaces/dfkps_8500.py
@@ -77,13 +77,10 @@ class Danfysik8500StreamInterface(CommonStreamInterface, StreamInterface):
 
         assert len(response) == 24, "length should have been 24 but was {}".format(len(response))
 
-        self.log.info(self.device.device_available)
-
         return response
 
     def set_address(self, value):
         self.device.set_address(value)
-        self.log.info(repr(self.device))
 
     @conditional_reply("comms_initialized")
     def get_address(self):

--- a/lewis_emulators/danfysik/interfaces/dfkps_8500.py
+++ b/lewis_emulators/danfysik/interfaces/dfkps_8500.py
@@ -17,8 +17,8 @@ class Danfysik8500StreamInterface(CommonStreamInterface, StreamInterface):
     Stream interface for a Danfysik model 8500.
     """
 
-    in_terminator = "\r\n"
-    out_terminator = "\r\n"
+    in_terminator = "\r"
+    out_terminator = "\n\r"
 
     protocol = 'model8500'
 
@@ -30,7 +30,8 @@ class Danfysik8500StreamInterface(CommonStreamInterface, StreamInterface):
         CmdBuilder("get_current").escape("AD 8").eos().build(),
         CmdBuilder("set_address").escape("ADR ").int().eos().build(),
         CmdBuilder("get_address").escape("ADR").eos().build(),
-        CmdBuilder("init_comms").escape("REM").build(),
+        CmdBuilder("init_comms").escape("REM").eos().build(),
+        CmdBuilder("init_comms").escape("UNLOCK").eos().build(),
     ]
 
     @conditional_reply("device_available")

--- a/lewis_emulators/danfysik/interfaces/dfkps_base.py
+++ b/lewis_emulators/danfysik/interfaces/dfkps_base.py
@@ -42,9 +42,6 @@ class CommonStreamInterface(object):
     @conditional_reply("device_available")
     @conditional_reply("comms_initialized")
     def get_current(self):
-        string = 'Retreiving current {} {}'.format(int(round(self.device.current)), self.device.comms_initialized)
-        self.log.info(string)
-        #self.log.info('retreiving current ', int(round(self.device.current)), self.device.comms_initialized)
         return int(round(self.device.current))
 
     @conditional_reply("comms_initialized")
@@ -54,9 +51,6 @@ class CommonStreamInterface(object):
     @conditional_reply("device_available")
     @conditional_reply("comms_initialized")
     def get_voltage(self):
-        #self.log.info('retreiving voltage ', str(int(round(self.device.voltage))), str(self.device.comms_initialized))
-        string = 'Retreiving voltage {} {}'.format(int(round(self.device.voltage)), self.device.device_available)
-        self.log.info(string)
         return int(round(self.device.voltage))
 
     @conditional_reply("comms_initialized")
@@ -94,5 +88,4 @@ class CommonStreamInterface(object):
         """
         Initialize comms of device
         """
-        self.log.info('initialised comms')
         self.device.comms_initialized = True

--- a/lewis_emulators/danfysik/interfaces/dfkps_base.py
+++ b/lewis_emulators/danfysik/interfaces/dfkps_base.py
@@ -70,12 +70,10 @@ class CommonStreamInterface(object):
 
     @conditional_reply("comms_initialized")
     def set_power_off(self):
-        self.log.info('power off')
         self.device.power = False
 
     @conditional_reply("comms_initialized")
     def set_power_on(self):
-        self.log.info('power on')
         self.device.power = True
 
     @abc.abstractmethod

--- a/lewis_emulators/danfysik/interfaces/dfkps_base.py
+++ b/lewis_emulators/danfysik/interfaces/dfkps_base.py
@@ -39,16 +39,24 @@ class CommonStreamInterface(object):
         """
         self.log.error("An error occurred at request " + repr(request) + ": " + repr(error))
 
+    @conditional_reply("device_available")
     @conditional_reply("comms_initialized")
     def get_current(self):
+        string = 'Retreiving current {} {}'.format(int(round(self.device.current)), self.device.comms_initialized)
+        self.log.info(string)
+        #self.log.info('retreiving current ', int(round(self.device.current)), self.device.comms_initialized)
         return int(round(self.device.current))
 
     @conditional_reply("comms_initialized")
     def set_current(self, value):
         self.device.current = value
 
+    @conditional_reply("device_available")
     @conditional_reply("comms_initialized")
     def get_voltage(self):
+        #self.log.info('retreiving voltage ', str(int(round(self.device.voltage))), str(self.device.comms_initialized))
+        string = 'Retreiving voltage {} {}'.format(int(round(self.device.voltage)), self.device.device_available)
+        self.log.info(string)
         return int(round(self.device.voltage))
 
     @conditional_reply("comms_initialized")
@@ -68,10 +76,12 @@ class CommonStreamInterface(object):
 
     @conditional_reply("comms_initialized")
     def set_power_off(self):
+        self.log.info('power off')
         self.device.power = False
 
     @conditional_reply("comms_initialized")
     def set_power_on(self):
+        self.log.info('power on')
         self.device.power = True
 
     @abc.abstractmethod
@@ -84,4 +94,5 @@ class CommonStreamInterface(object):
         """
         Initialize comms of device
         """
+        self.log.info('initialised comms')
         self.device.comms_initialized = True


### PR DESCRIPTION
# Description of work
Introduces PSU addresses for the LOQ danfysik 8500 and adds its command set

# Ticket
https://github.com/ISISComputingGroup/IBEX/issues/3720

# Acceptance criteria
- [ ] Device does not reply if the address is 'wrong'
- [x] Emulator works against series 8500 command set