### PR TITLE
Ticket3739 heliox

### DIFF
--- a/lewis_emulators/heliox/__init__.py
+++ b/lewis_emulators/heliox/__init__.py
@@ -1,0 +1,5 @@
+from .device import SimulatedHeliox
+from ..lewis_versions import LEWIS_LATEST
+
+framework_version = LEWIS_LATEST
+__all__ = ['SimulatedHeliox']

--- a/lewis_emulators/heliox/device.py
+++ b/lewis_emulators/heliox/device.py
@@ -4,6 +4,12 @@ from states import DefaultState
 from lewis.devices import StateMachineDevice
 
 
+class TemperatureChannel(object):
+    def __init__(self):
+        self.temperature = 0
+        self.temperature_sp = 0
+
+
 @has_log
 class SimulatedHeliox(StateMachineDevice):
 
@@ -16,6 +22,13 @@ class SimulatedHeliox(StateMachineDevice):
 
         self.temperature_stable = True
 
+        self.temperature_channels = {
+            "HE3SORB": TemperatureChannel(),
+            "HE4POT": TemperatureChannel(),
+            "HELOW": TemperatureChannel(),
+            "HEHIGH": TemperatureChannel(),
+        }
+
     def _get_state_handlers(self):
         return {
             'default': DefaultState()
@@ -26,3 +39,9 @@ class SimulatedHeliox(StateMachineDevice):
 
     def _get_transition_handlers(self):
         return OrderedDict([])
+
+    def backdoor_set_channel_temperature(self, channel, temperature):
+        self.temperature_channels[channel].temperature = temperature
+
+    def backdoor_set_channel_temperature_sp(self, channel, temperature_sp):
+        self.temperature_channels[channel].temperature_sp = temperature_sp

--- a/lewis_emulators/heliox/device.py
+++ b/lewis_emulators/heliox/device.py
@@ -50,3 +50,6 @@ class SimulatedHeliox(StateMachineDevice):
 
     def backdoor_set_channel_stability(self, channel, stability):
         self.temperature_channels[channel].stable = stability
+
+    def backdoor_set_channel_heater_auto(self, channel, heater_auto):
+        self.temperature_channels[channel].heater_auto = heater_auto

--- a/lewis_emulators/heliox/device.py
+++ b/lewis_emulators/heliox/device.py
@@ -5,11 +5,15 @@ from lewis.devices import StateMachineDevice
 
 
 class TemperatureChannel(object):
+    """
+    Class to represent an individual temperature channel on a Heliox fridge. e.g. He3Sorb or He4Pot channels.
+    """
     def __init__(self):
         self.temperature = 0
         self.temperature_sp = 0
         self.stable = True
         self.heater_auto = True
+        self.heater_percent = 0
 
 
 @has_log
@@ -53,3 +57,6 @@ class SimulatedHeliox(StateMachineDevice):
 
     def backdoor_set_channel_heater_auto(self, channel, heater_auto):
         self.temperature_channels[channel].heater_auto = heater_auto
+
+    def backdoor_set_channel_heater_percent(self, channel, percent):
+        self.temperature_channels[channel].heater_percent = percent

--- a/lewis_emulators/heliox/device.py
+++ b/lewis_emulators/heliox/device.py
@@ -14,8 +14,12 @@ class SimulatedHeliox(StateMachineDevice):
         self.temperature = 0
         self.temperature_sp = 0
 
+        self.temperature_stable = True
+
     def _get_state_handlers(self):
-        return {'default': DefaultState()}
+        return {
+            'default': DefaultState()
+        }
 
     def _get_initial_state(self):
         return 'default'

--- a/lewis_emulators/heliox/device.py
+++ b/lewis_emulators/heliox/device.py
@@ -8,6 +8,8 @@ class TemperatureChannel(object):
     def __init__(self):
         self.temperature = 0
         self.temperature_sp = 0
+        self.stable = True
+        self.heater_auto = True
 
 
 @has_log
@@ -45,3 +47,6 @@ class SimulatedHeliox(StateMachineDevice):
 
     def backdoor_set_channel_temperature_sp(self, channel, temperature_sp):
         self.temperature_channels[channel].temperature_sp = temperature_sp
+
+    def backdoor_set_channel_stability(self, channel, stability):
+        self.temperature_channels[channel].stable = stability

--- a/lewis_emulators/heliox/device.py
+++ b/lewis_emulators/heliox/device.py
@@ -1,0 +1,24 @@
+from collections import OrderedDict
+from lewis.core.logging import has_log
+from states import DefaultState
+from lewis.devices import StateMachineDevice
+
+
+@has_log
+class SimulatedHeliox(StateMachineDevice):
+
+    def _initialize_data(self):
+        """
+        Initialize all of the device's attributes.
+        """
+        self.temperature = 0
+        self.temperature_sp = 0
+
+    def _get_state_handlers(self):
+        return {'default': DefaultState()}
+
+    def _get_initial_state(self):
+        return 'default'
+
+    def _get_transition_handlers(self):
+        return OrderedDict([])

--- a/lewis_emulators/heliox/interfaces/__init__.py
+++ b/lewis_emulators/heliox/interfaces/__init__.py
@@ -1,0 +1,3 @@
+from .stream_interface import HelioxStreamInterface
+
+__all__ = ['HelioxStreamInterface']

--- a/lewis_emulators/heliox/interfaces/stream_interface.py
+++ b/lewis_emulators/heliox/interfaces/stream_interface.py
@@ -1,16 +1,221 @@
-from lewis.adapters.stream import StreamInterface, Cmd
+from lewis.adapters.stream import StreamInterface
 from lewis_emulators.utils.command_builder import CmdBuilder
+
+
+ISOBUS_PREFIX = "@1"
+DEVICE_NAME = "HelioxX"
 
 
 class HelioxStreamInterface(StreamInterface):
     commands = {
+        CmdBuilder("get_catalog")
+            .escape(ISOBUS_PREFIX).escape("READ:SYS:CAT").eos().build(),
+
+        CmdBuilder("set_heliox_setpoint")
+            .escape(ISOBUS_PREFIX).escape("SET:DEV:{}:HEL:SIG:TSET:".format(DEVICE_NAME)).float().escape("K").eos().build(),
+        CmdBuilder("get_heliox_status")
+            .escape(ISOBUS_PREFIX).escape("READ:DEV:").escape(DEVICE_NAME).escape(":HEL").eos().build(),
+
+        CmdBuilder("get_nickname")
+            .escape(ISOBUS_PREFIX).escape("READ:DEV:").any().escape(":NICK").eos().build(),
+
+        CmdBuilder("get_he3_sorb_temp")
+            .escape(ISOBUS_PREFIX).escape("READ:DEV:He3Sorb:TEMP").eos().build(),
+        CmdBuilder("get_he4_pot_temp")
+            .escape(ISOBUS_PREFIX).escape("READ:DEV:He4Pot:TEMP").eos().build(),
+        CmdBuilder("get_he_high_temp")
+            .escape(ISOBUS_PREFIX).escape("READ:DEV:HeHigh:TEMP").eos().build(),
+        CmdBuilder("get_he_low_temp")
+            .escape(ISOBUS_PREFIX).escape("READ:DEV:HeLow:TEMP").eos().build(),
     }
 
-    in_terminator = "\r"
-    out_terminator = "\r"
+    in_terminator = "\n"
+    out_terminator = "\n"
 
     def handle_error(self, request, error):
         err_string = "command was: {}, error was: {}: {}\n".format(request, error.__class__.__name__, error)
         print(err_string)
         self.log.error(err_string)
         return err_string
+
+    def get_heliox_status(self):
+        return "STAT:DEV:{}".format(DEVICE_NAME) + \
+               ":HEL:LOWT:2.5000K" \
+               ":BT:0.0000K" \
+               ":NVCN:17.000mB" \
+               ":RCTD:10.000K" \
+               ":RCST:20.000K" \
+               ":NVHT:17.000mB" \
+               ":RCTE:10.000K" \
+               ":SRBH:15.000K" \
+               ":PE:3.5000K" \
+               ":RGNA:1.0000K" \
+               ":PCT:2.0000K" \
+               ":SIG:H4PS:Stable" \
+               ":STAT:Regenerate" \
+               ":TEMP:{}K".format(self.device.temperature) + \
+               ":TSET:{}K".format(self.device.temperature_sp) + \
+               ":H3PS:Stable" \
+               ":SRBS:Stable" \
+               ":SRBR:32.000K" \
+               ":SCT:3.0000K" \
+               ":NVLT:10.000mB"
+
+    def get_catalog(self):
+        return "STAT:SYS:CAT" \
+               ":DEV:HelioxX:HEL" \
+               ":DEV:He3Sorb:TEMP" \
+               ":DEV:He4Pot:TEMP" \
+               ":DEV:HeLow:TEMP" \
+               ":DEV:HeHigh:TEMP"
+
+    def get_nickname(self, arg):
+        """
+        Returns a fake nickname. This is only implemented to allow this emulator to be used with the existing
+        labview driver, and the labview driver actually ignores the results (but not implementing the function causes
+        an error).
+        """
+        return "STAT:DEV:{}:NICK:{}".format(arg, "FAKENICKNAME")
+
+    def get_he3_sorb_temp(self):
+        return "STAT:DEV:He3Sorb:TEMP" \
+               ":EXCT:TYPE:UNIP:MAG:0" \
+               ":STAT:40000000" \
+               ":NICK:MB1.T1" \
+               ":LOOP:AUX:None" \
+               ":D:1.0" \
+               ":HTR:None" \
+               ":I:1.0" \
+               ":THTF:None" \
+               ":HSET:0" \
+               ":PIDT:OFF" \
+               ":ENAB:OFF" \
+               ":SWFL:None" \
+               ":FAUT:OFF" \
+               ":FSET:0" \
+               ":PIDF:None" \
+               ":P:1.0" \
+               ":SWMD:FIX" \
+               ":TSET:0.0000K" \
+               ":MAN:HVER:1" \
+               ":FVER:1.12" \
+               ":SERL:111450078" \
+               ":CAL:OFFS:0" \
+               ":COLDL:999.00K" \
+               ":INT:LIN:SCAL:1" \
+               ":FILE:None" \
+               ":HOTL:999.00K" \
+               ":TYPE:TCE:SIG:VOLT:-0.0038mV" \
+               ":CURR:-0.0000A" \
+               ":TEMP:1.2345K" \
+               ":POWR:0.0000W" \
+               ":RES:0.0000O" \
+               ":SLOP:0.0000O/K"
+
+    def get_he4_pot_temp(self):
+        return "STAT:DEV:He4Pot:TEMP" \
+               ":EXCT:TYPE:UNIP:MAG:0" \
+               ":STAT:40000000" \
+               ":NICK:MB1.T1" \
+               ":LOOP:AUX:None" \
+               ":D:1.0" \
+               ":HTR:None" \
+               ":I:1.0" \
+               ":THTF:None" \
+               ":HSET:0" \
+               ":PIDT:OFF" \
+               ":ENAB:OFF" \
+               ":SWFL:None" \
+               ":FAUT:OFF" \
+               ":FSET:0" \
+               ":PIDF:None" \
+               ":P:1.0" \
+               ":SWMD:FIX" \
+               ":TSET:0.0000K" \
+               ":MAN:HVER:1" \
+               ":FVER:1.12" \
+               ":SERL:111450078" \
+               ":CAL:OFFS:0" \
+               ":COLDL:999.00K" \
+               ":INT:LIN:SCAL:1" \
+               ":FILE:None" \
+               ":HOTL:999.00K" \
+               ":TYPE:TCE:SIG:VOLT:-0.0038mV" \
+               ":CURR:-0.0000A" \
+               ":TEMP:2.3456K" \
+               ":POWR:0.0000W" \
+               ":RES:0.0000O" \
+               ":SLOP:0.0000O/K"
+
+    def get_he_low_temp(self):
+        return "STAT:DEV:HeLow:TEMP" \
+               ":EXCT:TYPE:UNIP:MAG:0" \
+               ":STAT:40000000" \
+               ":NICK:MB1.T1" \
+               ":LOOP:AUX:None" \
+               ":D:1.0" \
+               ":HTR:None" \
+               ":I:1.0" \
+               ":THTF:None" \
+               ":HSET:0" \
+               ":PIDT:OFF" \
+               ":ENAB:OFF" \
+               ":SWFL:None" \
+               ":FAUT:OFF" \
+               ":FSET:0" \
+               ":PIDF:None" \
+               ":P:1.0" \
+               ":SWMD:FIX" \
+               ":TSET:0.0000K" \
+               ":MAN:HVER:1" \
+               ":FVER:1.12" \
+               ":SERL:111450078" \
+               ":CAL:OFFS:0" \
+               ":COLDL:999.00K" \
+               ":INT:LIN:SCAL:1" \
+               ":FILE:None" \
+               ":HOTL:999.00K" \
+               ":TYPE:TCE:SIG:VOLT:-0.0038mV" \
+               ":CURR:-0.0000A" \
+               ":TEMP:3.4567K" \
+               ":POWR:0.0000W" \
+               ":RES:0.0000O" \
+               ":SLOP:0.0000O/K"
+
+    def get_he_high_temp(self):
+        return "STAT:DEV:HeHigh:TEMP" \
+               ":EXCT:TYPE:UNIP:MAG:0" \
+               ":STAT:40000000" \
+               ":NICK:MB1.T1" \
+               ":LOOP:AUX:None" \
+               ":D:1.0" \
+               ":HTR:None" \
+               ":I:1.0" \
+               ":THTF:None" \
+               ":HSET:0" \
+               ":PIDT:OFF" \
+               ":ENAB:OFF" \
+               ":SWFL:None" \
+               ":FAUT:OFF" \
+               ":FSET:0" \
+               ":PIDF:None" \
+               ":P:1.0" \
+               ":SWMD:FIX" \
+               ":TSET:0.0000K" \
+               ":MAN:HVER:1" \
+               ":FVER:1.12" \
+               ":SERL:111450078" \
+               ":CAL:OFFS:0" \
+               ":COLDL:999.00K" \
+               ":INT:LIN:SCAL:1" \
+               ":FILE:None" \
+               ":HOTL:999.00K" \
+               ":TYPE:TCE:SIG:VOLT:-0.0038mV" \
+               ":CURR:-0.0000A" \
+               ":TEMP:4.5678K" \
+               ":POWR:0.0000W" \
+               ":RES:0.0000O" \
+               ":SLOP:0.0000O/K"
+
+    def set_heliox_setpoint(self, new_setpoint):
+        self.device.temperature_sp = new_setpoint

--- a/lewis_emulators/heliox/interfaces/stream_interface.py
+++ b/lewis_emulators/heliox/interfaces/stream_interface.py
@@ -1,0 +1,16 @@
+from lewis.adapters.stream import StreamInterface, Cmd
+from lewis_emulators.utils.command_builder import CmdBuilder
+
+
+class HelioxStreamInterface(StreamInterface):
+    commands = {
+    }
+
+    in_terminator = "\r"
+    out_terminator = "\r"
+
+    def handle_error(self, request, error):
+        err_string = "command was: {}, error was: {}: {}\n".format(request, error.__class__.__name__, error)
+        print(err_string)
+        self.log.error(err_string)
+        return err_string

--- a/lewis_emulators/heliox/interfaces/stream_interface.py
+++ b/lewis_emulators/heliox/interfaces/stream_interface.py
@@ -3,44 +3,7 @@ from lewis_emulators.utils.command_builder import CmdBuilder
 
 
 ISOBUS_PREFIX = "@1"
-DEVICE_NAME = "HelioxX"
-
-
-# Format of the long-style response when querying an individual temperature card.
-INDIVIDUAL_CHANNEL_LONG_RESPONSE_FORMAT = "STAT:DEV:{name}:TEMP" \
-               ":EXCT:TYPE:UNIP:MAG:0" \
-               ":STAT:40000000" \
-               ":NICK:MB1.T1" \
-               ":LOOP:AUX:None" \
-               ":D:1.0" \
-               ":HTR:None" \
-               ":I:1.0" \
-               ":THTF:None" \
-               ":HSET:0" \
-               ":PIDT:OFF" \
-               ":ENAB:OFF" \
-               ":SWFL:None" \
-               ":FAUT:OFF" \
-               ":FSET:0" \
-               ":PIDF:None" \
-               ":P:1.0" \
-               ":SWMD:FIX" \
-               ":TSET:{tset:.4f}K" \
-               ":MAN:HVER:1" \
-               ":FVER:1.12" \
-               ":SERL:111450078" \
-               ":CAL:OFFS:0" \
-               ":COLDL:999.00K" \
-               ":INT:LIN:SCAL:1" \
-               ":FILE:None" \
-               ":HOTL:999.00K" \
-               ":TYPE:TCE" \
-               ":SIG:VOLT:-0.0038mV" \
-               ":CURR:-0.0000A" \
-               ":TEMP:{temp:.4f}K" \
-               ":POWR:0.0000W" \
-               ":RES:0.0000O" \
-               ":SLOP:0.0000O/K"
+PRIMARY_DEVICE_NAME = "HelioxX"
 
 
 class HelioxStreamInterface(StreamInterface):
@@ -49,52 +12,34 @@ class HelioxStreamInterface(StreamInterface):
             .escape("READ:SYS:CAT").eos().build(),
 
         CmdBuilder("get_all_heliox_status").optional(ISOBUS_PREFIX)
-            .escape("READ:DEV:").escape(DEVICE_NAME).escape(":HEL").eos().build(),
+            .escape("READ:DEV:").escape(PRIMARY_DEVICE_NAME).escape(":HEL").eos().build(),
 
         CmdBuilder("get_heliox_temp").optional(ISOBUS_PREFIX)
-            .escape("READ:DEV:").escape(DEVICE_NAME).escape(":HEL:SIG:TEMP").eos().build(),
+            .escape("READ:DEV:").escape(PRIMARY_DEVICE_NAME).escape(":HEL:SIG:TEMP").eos().build(),
         CmdBuilder("get_heliox_temp_sp_rbv").optional(ISOBUS_PREFIX)
-            .escape("READ:DEV:").escape(DEVICE_NAME).escape(":HEL:SIG:TSET").eos().build(),
+            .escape("READ:DEV:").escape(PRIMARY_DEVICE_NAME).escape(":HEL:SIG:TSET").eos().build(),
         CmdBuilder("get_heliox_stable").optional(ISOBUS_PREFIX)
-            .escape("READ:DEV:").escape(DEVICE_NAME).escape(":HEL:SIG:H3PS").eos().build(),
+            .escape("READ:DEV:").escape(PRIMARY_DEVICE_NAME).escape(":HEL:SIG:H3PS").eos().build(),
 
         CmdBuilder("set_heliox_setpoint").optional(ISOBUS_PREFIX)
-            .escape("SET:DEV:{}:HEL:SIG:TSET:".format(DEVICE_NAME)).float().escape("K").eos().build(),
+            .escape("SET:DEV:{}:HEL:SIG:TSET:".format(PRIMARY_DEVICE_NAME)).float().escape("K").eos().build(),
 
         CmdBuilder("get_nickname").optional(ISOBUS_PREFIX)
             .escape("READ:DEV:").any().escape(":NICK").eos().build(),
 
-        CmdBuilder("get_all_he3_sorb_status").optional(ISOBUS_PREFIX)
-            .escape("READ:DEV:He3Sorb:TEMP").eos().build(),
-        CmdBuilder("get_all_he4_pot_status").optional(ISOBUS_PREFIX)
-            .escape("READ:DEV:He4Pot:TEMP").eos().build(),
-        CmdBuilder("get_all_he_high_status").optional(ISOBUS_PREFIX)
-            .escape("READ:DEV:HeHigh:TEMP").eos().build(),
-        CmdBuilder("get_all_he_low_status").optional(ISOBUS_PREFIX)
-            .escape("READ:DEV:HeLow:TEMP").eos().build(),
-
-        CmdBuilder("get_he3_sorb_temp").optional(ISOBUS_PREFIX)
-            .escape("READ:DEV:He3Sorb:TEMP:SIG:TEMP").eos().build(),
-        CmdBuilder("get_he4_pot_temp").optional(ISOBUS_PREFIX)
-            .escape("READ:DEV:He4Pot:TEMP:SIG:TEMP").eos().build(),
-        CmdBuilder("get_he_high_temp").optional(ISOBUS_PREFIX)
-            .escape("READ:DEV:HeHigh:TEMP:SIG:TEMP").eos().build(),
-        CmdBuilder("get_he_low_temp").optional(ISOBUS_PREFIX)
-            .escape("READ:DEV:HeLow:TEMP:SIG:TEMP").eos().build(),
-
-        CmdBuilder("get_he3_sorb_temp_sp").optional(ISOBUS_PREFIX)
-            .escape("READ:DEV:He3Sorb:TEMP:LOOP:TSET").eos().build(),
-        CmdBuilder("get_he4_pot_temp_sp").optional(ISOBUS_PREFIX)
-            .escape("READ:DEV:He4Pot:TEMP:LOOP:TSET").eos().build(),
-        CmdBuilder("get_he_high_temp_sp").optional(ISOBUS_PREFIX)
-            .escape("READ:DEV:HeHigh:TEMP:LOOP:TSET").eos().build(),
-        CmdBuilder("get_he_low_temp_sp").optional(ISOBUS_PREFIX)
-            .escape("READ:DEV:HeLow:TEMP:LOOP:TSET").eos().build(),
+        CmdBuilder("get_channel_status").optional(ISOBUS_PREFIX)
+            .escape("READ:DEV:").arg(r"[^:]*").escape(":TEMP").eos().build(),
+        CmdBuilder("get_channel_temp").optional(ISOBUS_PREFIX)
+            .escape("READ:DEV:").arg(r"[^:]*").escape(":TEMP:SIG:TEMP").eos().build(),
+        CmdBuilder("get_channel_temp_sp").optional(ISOBUS_PREFIX)
+            .escape("READ:DEV:").arg(r"[^:]*").escape(":TEMP:LOOP:TSET").eos().build(),
+        CmdBuilder("get_channel_heater_auto").optional(ISOBUS_PREFIX)
+            .escape("READ:DEV:").arg(r"[^:]*").escape(":TEMP:LOOP:ENAB").eos().build(),
 
         CmdBuilder("get_he3_sorb_stable").optional(ISOBUS_PREFIX)
-            .escape("READ:DEV:{}:HEL:SIG:SRBS".format(DEVICE_NAME)).eos().build(),
+            .escape("READ:DEV:{}:HEL:SIG:SRBS".format(PRIMARY_DEVICE_NAME)).eos().build(),
         CmdBuilder("get_he4_pot_stable").optional(ISOBUS_PREFIX)
-            .escape("READ:DEV:{}:HEL:SIG:H4PS".format(DEVICE_NAME)).eos().build(),
+            .escape("READ:DEV:{}:HEL:SIG:H4PS".format(PRIMARY_DEVICE_NAME)).eos().build(),
     }
 
     in_terminator = "\n"
@@ -111,7 +56,7 @@ class HelioxStreamInterface(StreamInterface):
         This function is used by the labview VI. In EPICS it is more convenient to ask for the parameters individually,
         so we don't use this large function which generates all of the possible status information.
         """
-        return "STAT:DEV:{}".format(DEVICE_NAME) + \
+        return "STAT:DEV:{}".format(PRIMARY_DEVICE_NAME) + \
                ":HEL:LOWT:2.5000K" \
                ":BT:0.0000K" \
                ":NVCN:17.000mB" \
@@ -152,34 +97,6 @@ class HelioxStreamInterface(StreamInterface):
         """
         return "STAT:DEV:{}:NICK:{}".format(arg, "FAKENICKNAME")
 
-    def get_all_he3_sorb_status(self):
-        return INDIVIDUAL_CHANNEL_LONG_RESPONSE_FORMAT.format(
-            name="He3Sorb",
-            tset=self.device.temperature_channels["HE3SORB"].temperature_sp,
-            temp=self.device.temperature_channels["HE3SORB"].temperature,
-        )
-
-    def get_all_he4_pot_status(self):
-        return INDIVIDUAL_CHANNEL_LONG_RESPONSE_FORMAT.format(
-            name="He4Pot",
-            tset=self.device.temperature_channels["HE4POT"].temperature_sp,
-            temp=self.device.temperature_channels["HE4POT"].temperature,
-        )
-
-    def get_all_he_high_status(self):
-        return INDIVIDUAL_CHANNEL_LONG_RESPONSE_FORMAT.format(
-            name="HeHigh",
-            tset=self.device.temperature_channels["HEHIGH"].temperature_sp,
-            temp=self.device.temperature_channels["HEHIGH"].temperature,
-        )
-
-    def get_all_he_low_status(self):
-        return INDIVIDUAL_CHANNEL_LONG_RESPONSE_FORMAT.format(
-            name="HeLow",
-            tset=self.device.temperature_channels["HELOW"].temperature_sp,
-            temp=self.device.temperature_channels["HELOW"].temperature,
-        )
-
     def set_heliox_setpoint(self, new_setpoint):
         self.device.temperature_sp = new_setpoint
         return self.get_heliox_temp_sp_rbv()
@@ -191,42 +108,69 @@ class HelioxStreamInterface(StreamInterface):
         return "STAT:DEV:HelioxX:HEL:SIG:TSET:{:.4f}K".format(self.device.temperature_sp)
 
     def get_heliox_stable(self):
-        return "STAT:DEV:{}:HEL:SIG:H3PS:{}".format(DEVICE_NAME, "Stable" if self.device.temperature_stable else "Unstable")
+        return "STAT:DEV:{}:HEL:SIG:H3PS:{}"\
+            .format(PRIMARY_DEVICE_NAME, "Stable" if self.device.temperature_stable else "Unstable")
 
-    # Individual channel temperatures
+    def get_channel_status(self, channel):
+        temperature_channel = self.device.temperature_channels[channel.upper()]
+        return "STAT:DEV:{name}:TEMP" \
+               ":EXCT:TYPE:UNIP:MAG:0" \
+               ":STAT:40000000" \
+               ":NICK:MB1.T1" \
+               ":LOOP:AUX:None" \
+               ":D:1.0" \
+               ":HTR:None" \
+               ":I:1.0" \
+               ":THTF:None" \
+               ":HSET:0" \
+               ":PIDT:OFF" \
+               ":ENAB:{heater_auto}" \
+               ":SWFL:None" \
+               ":FAUT:OFF" \
+               ":FSET:0" \
+               ":PIDF:None" \
+               ":P:1.0" \
+               ":SWMD:FIX" \
+               ":TSET:{tset:.4f}K" \
+               ":MAN:HVER:1" \
+               ":FVER:1.12" \
+               ":SERL:111450078" \
+               ":CAL:OFFS:0" \
+               ":COLDL:999.00K" \
+               ":INT:LIN:SCAL:1" \
+               ":FILE:None" \
+               ":HOTL:999.00K" \
+               ":TYPE:TCE" \
+               ":SIG:VOLT:-0.0038mV" \
+               ":CURR:-0.0000A" \
+               ":TEMP:{temp:.4f}K" \
+               ":POWR:0.0000W" \
+               ":RES:0.0000O" \
+               ":SLOP:0.0000O/K".format(
+                    name=channel,
+                    tset=temperature_channel.temperature_sp,
+                    temp=temperature_channel.temperature,
+                    heater_auto="ON" if temperature_channel.heater_auto else "OFF",
+                )
 
-    def get_he3_sorb_temp(self):
-        return "STAT:DEV:He3Sorb:TEMP:SIG:TEMP:{:.4f}K".format(self.device.temperature_channels["HE3SORB"].temperature)
+    def get_channel_temp(self, chan):
+        return "STAT:DEV:{}:TEMP:SIG:TEMP:{:.4f}K"\
+            .format(chan, self.device.temperature_channels[chan.upper()].temperature)
 
-    def get_he4_pot_temp(self):
-        return "STAT:DEV:He4Pot:TEMP:SIG:TEMP:{:.4f}K".format(self.device.temperature_channels["HE4POT"].temperature)
+    def get_channel_temp_sp(self, chan):
+        return "STAT:DEV:{}:TEMP:LOOP:TSET:{:.4f}K"\
+            .format(chan, self.device.temperature_channels[chan.upper()].temperature_sp)
 
-    def get_he_low_temp(self):
-        return "STAT:DEV:HeLow:TEMP:SIG:TEMP:{:.4f}K".format(self.device.temperature_channels["HELOW"].temperature)
-
-    def get_he_high_temp(self):
-        return "STAT:DEV:HeHigh:TEMP:SIG:TEMP:{:.4f}K".format(self.device.temperature_channels["HEHIGH"].temperature)
-
-    # Individual channel temperature setpoint readbacks
-
-    def get_he3_sorb_temp_sp(self):
-        return "STAT:DEV:He3Sorb:TEMP:LOOP:TSET:{:.4f}K".format(self.device.temperature_channels["HE3SORB"].temperature_sp)
-
-    def get_he4_pot_temp_sp(self):
-        return "STAT:DEV:He4Pot:TEMP:LOOP:TSET:{:.4f}K".format(self.device.temperature_channels["HE4POT"].temperature_sp)
-
-    def get_he_low_temp_sp(self):
-        return "STAT:DEV:HeLow:TEMP:LOOP:TSET:{:.4f}K".format(self.device.temperature_channels["HELOW"].temperature_sp)
-
-    def get_he_high_temp_sp(self):
-        return "STAT:DEV:HeHigh:TEMP:LOOP:TSET:{:.4f}K".format(self.device.temperature_channels["HEHIGH"].temperature_sp)
+    def get_channel_heater_auto(self, chan):
+        return "STAT:DEV:{}:TEMP:LOOP:ENAB:{}"\
+            .format(chan, "ON" if self.device.temperature_channels[chan.upper()].heater_auto else "OFF")
     
     # Individual channel stabilities
 
     def get_he3_sorb_stable(self):
         return "STAT:DEV:{}:HEL:SIG:SRBS:{}"\
-            .format(DEVICE_NAME, "Stable" if self.device.temperature_channels["HE3SORB"].stable else "Unstable")
+            .format(PRIMARY_DEVICE_NAME, "Stable" if self.device.temperature_channels["HE3SORB"].stable else "Unstable")
 
     def get_he4_pot_stable(self):
         return "STAT:DEV:{}:HEL:SIG:H4PS:{}"\
-            .format(DEVICE_NAME, "Stable" if self.device.temperature_channels["HE4POT"].stable else "Unstable")
+            .format(PRIMARY_DEVICE_NAME, "Stable" if self.device.temperature_channels["HE4POT"].stable else "Unstable")

--- a/lewis_emulators/heliox/interfaces/stream_interface.py
+++ b/lewis_emulators/heliox/interfaces/stream_interface.py
@@ -35,6 +35,8 @@ class HelioxStreamInterface(StreamInterface):
             .escape("READ:DEV:").arg(r"[^:]*").escape(":TEMP:LOOP:TSET").eos().build(),
         CmdBuilder("get_channel_heater_auto").optional(ISOBUS_PREFIX)
             .escape("READ:DEV:").arg(r"[^:]*").escape(":TEMP:LOOP:ENAB").eos().build(),
+        CmdBuilder("get_channel_heater_percentage").optional(ISOBUS_PREFIX)
+            .escape("READ:DEV:").arg(r"[^:]*").escape(":TEMP:LOOP:HSET").eos().build(),
 
         CmdBuilder("get_he3_sorb_stable").optional(ISOBUS_PREFIX)
             .escape("READ:DEV:{}:HEL:SIG:SRBS".format(PRIMARY_DEVICE_NAME)).eos().build(),
@@ -122,7 +124,7 @@ class HelioxStreamInterface(StreamInterface):
                ":HTR:None" \
                ":I:1.0" \
                ":THTF:None" \
-               ":HSET:0" \
+               ":HSET:{heater_percent:.4f}" \
                ":PIDT:OFF" \
                ":ENAB:{heater_auto}" \
                ":SWFL:None" \
@@ -151,6 +153,7 @@ class HelioxStreamInterface(StreamInterface):
                     tset=temperature_channel.temperature_sp,
                     temp=temperature_channel.temperature,
                     heater_auto="ON" if temperature_channel.heater_auto else "OFF",
+                    heater_percent=temperature_channel.heater_percent,
                 )
 
     def get_channel_temp(self, chan):
@@ -164,6 +167,10 @@ class HelioxStreamInterface(StreamInterface):
     def get_channel_heater_auto(self, chan):
         return "STAT:DEV:{}:TEMP:LOOP:ENAB:{}"\
             .format(chan, "ON" if self.device.temperature_channels[chan.upper()].heater_auto else "OFF")
+
+    def get_channel_heater_percentage(self, chan):
+        return "STAT:DEV:{}:TEMP:LOOP:HSET:{:.4f}"\
+            .format(chan, self.device.temperature_channels[chan.upper()].heater_percent)
     
     # Individual channel stabilities
 

--- a/lewis_emulators/heliox/interfaces/stream_interface.py
+++ b/lewis_emulators/heliox/interfaces/stream_interface.py
@@ -6,6 +6,43 @@ ISOBUS_PREFIX = "@1"
 DEVICE_NAME = "HelioxX"
 
 
+# Format of the long-style response when querying an individual temperature card.
+INDIVIDUAL_CHANNEL_RESPONSE_FORMAT = "STAT:DEV:{name}:TEMP" \
+               ":EXCT:TYPE:UNIP:MAG:0" \
+               ":STAT:40000000" \
+               ":NICK:MB1.T1" \
+               ":LOOP:AUX:None" \
+               ":D:1.0" \
+               ":HTR:None" \
+               ":I:1.0" \
+               ":THTF:None" \
+               ":HSET:0" \
+               ":PIDT:OFF" \
+               ":ENAB:OFF" \
+               ":SWFL:None" \
+               ":FAUT:OFF" \
+               ":FSET:0" \
+               ":PIDF:None" \
+               ":P:1.0" \
+               ":SWMD:FIX" \
+               ":TSET:{tset:.4f}K" \
+               ":MAN:HVER:1" \
+               ":FVER:1.12" \
+               ":SERL:111450078" \
+               ":CAL:OFFS:0" \
+               ":COLDL:999.00K" \
+               ":INT:LIN:SCAL:1" \
+               ":FILE:None" \
+               ":HOTL:999.00K" \
+               ":TYPE:TCE" \
+               ":SIG:VOLT:-0.0038mV" \
+               ":CURR:-0.0000A" \
+               ":TEMP:{temp:.4f}K" \
+               ":POWR:0.0000W" \
+               ":RES:0.0000O" \
+               ":SLOP:0.0000O/K"
+
+
 class HelioxStreamInterface(StreamInterface):
     commands = {
         CmdBuilder("get_catalog").optional(ISOBUS_PREFIX)
@@ -35,6 +72,24 @@ class HelioxStreamInterface(StreamInterface):
             .escape("READ:DEV:HeHigh:TEMP").eos().build(),
         CmdBuilder("get_all_he_low_status").optional(ISOBUS_PREFIX)
             .escape("READ:DEV:HeLow:TEMP").eos().build(),
+
+        CmdBuilder("get_he3_sorb_temp").optional(ISOBUS_PREFIX)
+            .escape("READ:DEV:He3Sorb:TEMP:SIG:TEMP").eos().build(),
+        CmdBuilder("get_he4_pot_temp").optional(ISOBUS_PREFIX)
+            .escape("READ:DEV:He4Pot:TEMP:SIG:TEMP").eos().build(),
+        CmdBuilder("get_he_high_temp").optional(ISOBUS_PREFIX)
+            .escape("READ:DEV:HeHigh:TEMP:SIG:TEMP").eos().build(),
+        CmdBuilder("get_he_low_temp").optional(ISOBUS_PREFIX)
+            .escape("READ:DEV:HeLow:TEMP:SIG:TEMP").eos().build(),
+
+        CmdBuilder("get_he3_sorb_temp_sp").optional(ISOBUS_PREFIX)
+            .escape("READ:DEV:He3Sorb:TEMP:LOOP:TSET").eos().build(),
+        CmdBuilder("get_he4_pot_temp_sp").optional(ISOBUS_PREFIX)
+            .escape("READ:DEV:He4Pot:TEMP:LOOP:TSET").eos().build(),
+        CmdBuilder("get_he_high_temp_sp").optional(ISOBUS_PREFIX)
+            .escape("READ:DEV:HeHigh:TEMP:LOOP:TSET").eos().build(),
+        CmdBuilder("get_he_low_temp_sp").optional(ISOBUS_PREFIX)
+            .escape("READ:DEV:HeLow:TEMP:LOOP:TSET").eos().build(),
     }
 
     in_terminator = "\n"
@@ -74,6 +129,9 @@ class HelioxStreamInterface(StreamInterface):
                ":NVLT:10.000mB"
 
     def get_catalog(self):
+        """
+        This is only needed by the LabVIEW driver - it is not used by EPICS.
+        """
         return "STAT:SYS:CAT" \
                ":DEV:HelioxX:HEL" \
                ":DEV:He3Sorb:TEMP" \
@@ -90,148 +148,32 @@ class HelioxStreamInterface(StreamInterface):
         return "STAT:DEV:{}:NICK:{}".format(arg, "FAKENICKNAME")
 
     def get_all_he3_sorb_status(self):
-        return "STAT:DEV:He3Sorb:TEMP" \
-               ":EXCT:TYPE:UNIP:MAG:0" \
-               ":STAT:40000000" \
-               ":NICK:MB1.T1" \
-               ":LOOP:AUX:None" \
-               ":D:1.0" \
-               ":HTR:None" \
-               ":I:1.0" \
-               ":THTF:None" \
-               ":HSET:0" \
-               ":PIDT:OFF" \
-               ":ENAB:OFF" \
-               ":SWFL:None" \
-               ":FAUT:OFF" \
-               ":FSET:0" \
-               ":PIDF:None" \
-               ":P:1.0" \
-               ":SWMD:FIX" \
-               ":TSET:0.0000K" \
-               ":MAN:HVER:1" \
-               ":FVER:1.12" \
-               ":SERL:111450078" \
-               ":CAL:OFFS:0" \
-               ":COLDL:999.00K" \
-               ":INT:LIN:SCAL:1" \
-               ":FILE:None" \
-               ":HOTL:999.00K" \
-               ":TYPE:TCE" \
-               ":SIG:VOLT:-0.0038mV" \
-               ":CURR:-0.0000A" \
-               ":TEMP:1.2345K" \
-               ":POWR:0.0000W" \
-               ":RES:0.0000O" \
-               ":SLOP:0.0000O/K"
+        return INDIVIDUAL_CHANNEL_RESPONSE_FORMAT.format(
+            name="He3Sorb",
+            tset=self.device.temperature_channels["HE3SORB"].temperature_sp,
+            temp=self.device.temperature_channels["HE3SORB"].temperature,
+        )
 
     def get_all_he4_pot_status(self):
-        return "STAT:DEV:He4Pot:TEMP" \
-               ":EXCT:TYPE:UNIP:MAG:0" \
-               ":STAT:40000000" \
-               ":NICK:MB1.T1" \
-               ":LOOP:AUX:None" \
-               ":D:1.0" \
-               ":HTR:None" \
-               ":I:1.0" \
-               ":THTF:None" \
-               ":HSET:0" \
-               ":PIDT:OFF" \
-               ":ENAB:OFF" \
-               ":SWFL:None" \
-               ":FAUT:OFF" \
-               ":FSET:0" \
-               ":PIDF:None" \
-               ":P:1.0" \
-               ":SWMD:FIX" \
-               ":TSET:0.0000K" \
-               ":MAN:HVER:1" \
-               ":FVER:1.12" \
-               ":SERL:111450078" \
-               ":CAL:OFFS:0" \
-               ":COLDL:999.00K" \
-               ":INT:LIN:SCAL:1" \
-               ":FILE:None" \
-               ":HOTL:999.00K" \
-               ":TYPE:TCE" \
-               ":SIG:VOLT:-0.0038mV" \
-               ":CURR:-0.0000A" \
-               ":TEMP:2.3456K" \
-               ":POWR:0.0000W" \
-               ":RES:0.0000O" \
-               ":SLOP:0.0000O/K"
-
-    def get_all_he_low_status(self):
-        return "STAT:DEV:HeLow:TEMP" \
-               ":EXCT:TYPE:UNIP:MAG:0" \
-               ":STAT:40000000" \
-               ":NICK:MB1.T1" \
-               ":LOOP:AUX:None" \
-               ":D:1.0" \
-               ":HTR:None" \
-               ":I:1.0" \
-               ":THTF:None" \
-               ":HSET:0" \
-               ":PIDT:OFF" \
-               ":ENAB:OFF" \
-               ":SWFL:None" \
-               ":FAUT:OFF" \
-               ":FSET:0" \
-               ":PIDF:None" \
-               ":P:1.0" \
-               ":SWMD:FIX" \
-               ":TSET:0.0000K" \
-               ":MAN:HVER:1" \
-               ":FVER:1.12" \
-               ":SERL:111450078" \
-               ":CAL:OFFS:0" \
-               ":COLDL:999.00K" \
-               ":INT:LIN:SCAL:1" \
-               ":FILE:None" \
-               ":HOTL:999.00K" \
-               ":TYPE:TCE" \
-               ":SIG:VOLT:-0.0038mV" \
-               ":CURR:-0.0000A" \
-               ":TEMP:3.4567K" \
-               ":POWR:0.0000W" \
-               ":RES:0.0000O" \
-               ":SLOP:0.0000O/K"
+        return INDIVIDUAL_CHANNEL_RESPONSE_FORMAT.format(
+            name="He4Pot",
+            tset=self.device.temperature_channels["HE4POT"].temperature_sp,
+            temp=self.device.temperature_channels["HE4POT"].temperature,
+        )
 
     def get_all_he_high_status(self):
-        return "STAT:DEV:HeHigh:TEMP" \
-               ":EXCT:TYPE:UNIP:MAG:0" \
-               ":STAT:40000000" \
-               ":NICK:MB1.T1" \
-               ":LOOP:AUX:None" \
-               ":D:1.0" \
-               ":HTR:None" \
-               ":I:1.0" \
-               ":THTF:None" \
-               ":HSET:0" \
-               ":PIDT:OFF" \
-               ":ENAB:OFF" \
-               ":SWFL:None" \
-               ":FAUT:OFF" \
-               ":FSET:0" \
-               ":PIDF:None" \
-               ":P:1.0" \
-               ":SWMD:FIX" \
-               ":TSET:0.0000K" \
-               ":MAN:HVER:1" \
-               ":FVER:1.12" \
-               ":SERL:111450078" \
-               ":CAL:OFFS:0" \
-               ":COLDL:999.00K" \
-               ":INT:LIN:SCAL:1" \
-               ":FILE:None" \
-               ":HOTL:999.00K" \
-               ":TYPE:TCE" \
-               ":SIG:VOLT:-0.0038mV" \
-               ":CURR:-0.0000A" \
-               ":TEMP:4.5678K" \
-               ":POWR:0.0000W" \
-               ":RES:0.0000O" \
-               ":SLOP:0.0000O/K"
+        return INDIVIDUAL_CHANNEL_RESPONSE_FORMAT.format(
+            name="HeHigh",
+            tset=self.device.temperature_channels["HEHIGH"].temperature_sp,
+            temp=self.device.temperature_channels["HEHIGH"].temperature,
+        )
+
+    def get_all_he_low_status(self):
+        return INDIVIDUAL_CHANNEL_RESPONSE_FORMAT.format(
+            name="HeLow",
+            tset=self.device.temperature_channels["HELOW"].temperature_sp,
+            temp=self.device.temperature_channels["HELOW"].temperature,
+        )
 
     def set_heliox_setpoint(self, new_setpoint):
         self.device.temperature_sp = new_setpoint
@@ -245,3 +187,27 @@ class HelioxStreamInterface(StreamInterface):
 
     def get_heliox_stable(self):
         return "STAT:DEV:{}:HEL:SIG:H3PS:{}".format(DEVICE_NAME, "Stable" if self.device.temperature_stable else "Unstable")
+
+    def get_he3_sorb_temp(self):
+        return "STAT:DEV:He3Sorb:TEMP:SIG:TEMP:{:.4f}K".format(self.device.temperature_channels["HE3SORB"].temperature)
+
+    def get_he4_pot_temp(self):
+        return "STAT:DEV:He4Pot:TEMP:SIG:TEMP:{:.4f}K".format(self.device.temperature_channels["HE4POT"].temperature)
+
+    def get_he_low_temp(self):
+        return "STAT:DEV:HeLow:TEMP:SIG:TEMP:{:.4f}K".format(self.device.temperature_channels["HELOW"].temperature)
+
+    def get_he_high_temp(self):
+        return "STAT:DEV:HeHigh:TEMP:SIG:TEMP:{:.4f}K".format(self.device.temperature_channels["HEHIGH"].temperature)
+
+    def get_he3_sorb_temp_sp(self):
+        return "STAT:DEV:He3Sorb:TEMP:LOOP:TSET:{:.4f}K".format(self.device.temperature_channels["HE3SORB"].temperature_sp)
+
+    def get_he4_pot_temp_sp(self):
+        return "STAT:DEV:He4Pot:TEMP:LOOP:TSET:{:.4f}K".format(self.device.temperature_channels["HE4POT"].temperature_sp)
+
+    def get_he_low_temp_sp(self):
+        return "STAT:DEV:HeLow:TEMP:LOOP:TSET:{:.4f}K".format(self.device.temperature_channels["HELOW"].temperature_sp)
+
+    def get_he_high_temp_sp(self):
+        return "STAT:DEV:HeHigh:TEMP:LOOP:TSET:{:.4f}K".format(self.device.temperature_channels["HEHIGH"].temperature_sp)

--- a/lewis_emulators/heliox/states.py
+++ b/lewis_emulators/heliox/states.py
@@ -1,0 +1,11 @@
+from lewis.core import approaches
+from lewis.core.statemachine import State
+
+
+class DefaultState(State):
+    def in_state(self, dt):
+        device = self._context
+
+        rate = 10
+
+        device.temperature = approaches.linear(device.temperature, device.temperature_sp, rate, dt)


### PR DESCRIPTION
Write an emulator for an Oxford Instruments Mercury Heliox for ticket https://github.com/ISISComputingGroup/IBEX/issues/3739

This emulator supports two protocols simultaneously:
- A long form protocol currently used by the VI and could be used by the IOC
- A short form protocol which I would be better for the IOC, if it works correctly with the hardware

It is set up to implement enough of the protocol that it can talk sensibly to the Heliox Labview VI via a hardware serial loopback and the `com2tcp` script. If the reviewer wants to check this and needs help setting it up, give me a shout.

Note: the labview VI doesn't work with recent versions of labview (2018). It works OK on DEMO (2014).