### PR TITLE
Ticket 4623: Added the amplitude reading to the Attocube emulator

### DIFF
--- a/lewis_emulators/attocube_anc350/device.py
+++ b/lewis_emulators/attocube_anc350/device.py
@@ -13,6 +13,10 @@ class SimulatedAttocubeANC350(StateMachineDevice):
         self.position_setpoint = 0
         self.speed = 10
         self.start_move = False
+        self.amplitude = 30000
+
+    def set_amplitude(self, amplitude):
+        self.amplitude = amplitude
 
     def move(self):
         self.start_move = True

--- a/lewis_emulators/attocube_anc350/device.py
+++ b/lewis_emulators/attocube_anc350/device.py
@@ -14,6 +14,7 @@ class SimulatedAttocubeANC350(StateMachineDevice):
         self.speed = 10
         self.start_move = False
         self.amplitude = 30000
+        self.axis_on = True
 
     def set_amplitude(self, amplitude):
         self.amplitude = amplitude
@@ -24,6 +25,9 @@ class SimulatedAttocubeANC350(StateMachineDevice):
     def set_position_setpoint(self, position):
         self.position_setpoint = position
 
+    def set_axis_on(self, on_state):
+        self.axis_on = (on_state == 1)
+
     def _get_state_handlers(self):
         return {DefaultState.NAME: DefaultState(),
                 MovingState.NAME: MovingState()}
@@ -33,6 +37,6 @@ class SimulatedAttocubeANC350(StateMachineDevice):
 
     def _get_transition_handlers(self):
         return OrderedDict([
-            ((DefaultState.NAME, MovingState.NAME), lambda: self.start_move),
+            ((DefaultState.NAME, MovingState.NAME), lambda: self.start_move and self.axis_on),
             ((MovingState.NAME, DefaultState.NAME), lambda: self.position_setpoint == self.position),
         ])

--- a/lewis_emulators/attocube_anc350/interfaces/stream_interface.py
+++ b/lewis_emulators/attocube_anc350/interfaces/stream_interface.py
@@ -42,7 +42,7 @@ ID_ANC_STOP_EN = 0x0450  # Enables 'hump' detection
 ID_ANC_REGSPD_SELSP = 0x054A  # Type of setpoint for the speed
 ID_ANC_TARGET = 0x0408  # The target to move to
 ID_ANC_RUN_TARGET = 0x040d  # Actually start the move to target
-
+ID_ANC_AXIS_ON = 0x3030  # Turn the axis on (on power cycle the axis is turned off
 
 # Status bitmask
 ANC_STATUS_RUNNING = 0x0001
@@ -152,7 +152,8 @@ class AttocubeANC350StreamInterface(StreamInterface):
         command_mapping = {
             ID_ANC_TARGET: partial(self.device.set_position_setpoint, position=data[0]),
             ID_ANC_RUN_TARGET: self.device.move,
-            ID_ANC_AMPL: partial(self.device.set_amplitude, data[0])
+            ID_ANC_AMPL: partial(self.device.set_amplitude, data[0]),
+            ID_ANC_AXIS_ON: partial(self.device.set_axis_on, data[0]),
         }
 
         try:

--- a/lewis_emulators/attocube_anc350/interfaces/stream_interface.py
+++ b/lewis_emulators/attocube_anc350/interfaces/stream_interface.py
@@ -152,9 +152,12 @@ class AttocubeANC350StreamInterface(StreamInterface):
         command_mapping = {
             ID_ANC_TARGET: partial(self.device.set_position_setpoint, position=data[0]),
             ID_ANC_RUN_TARGET: self.device.move,
+            ID_ANC_AMPL: partial(self.device.set_amplitude, data[0])
         }
+
         try:
             command_mapping[address]()
+            print("Device amp is {}".format(self.device.amplitude))
         except KeyError:
             pass  # Ignore unimplemented commands for now
         return generate_response(address, index, correlation_num)
@@ -169,7 +172,7 @@ class AttocubeANC350StreamInterface(StreamInterface):
             ID_ANC_REGSPD_SETP: self.device.speed,
             ID_ANC_SENSOR_VOLT: 2000,
             ID_ANC_MAX_AMP: 60000,
-            ID_ANC_AMPL: 30000,
+            ID_ANC_AMPL: self.device.amplitude,
             ID_ANC_FAST_FREQ: 1000,
         }
         try:


### PR DESCRIPTION
Added the `axis_on` status to the emulator. See https://github.com/ISISComputingGroup/IBEX/issues/4623

