### PR TITLE
Ticket5042 danfysik changes rework

### DIFF
--- a/lewis_emulators/danfysik/device.py
+++ b/lewis_emulators/danfysik/device.py
@@ -30,6 +30,9 @@ class SimulatedDanfysik(StateMachineDevice):
 
         self.current = 0
         self.voltage = 0
+        self.voltage_read_factor = 1
+        self.current_read_factor = 1
+        self.current_write_factor = 1
 
         self.field_units = FieldUnits.GAUSS
         self.negative_polarity = False
@@ -91,6 +94,28 @@ class SimulatedDanfysik(StateMachineDevice):
         Reinitialise the device state (this is mainly used via the backdoor to clean up between tests)
         """
         self._initialize_data()
+
+    def set_current_read_factor(self, factor):
+        self.current_read_factor = factor
+
+    def set_current_write_factor(self, factor):
+        self.current_write_factor = factor
+
+    def get_current(self):
+        current_pp100k = self.current / self.current_read_factor
+        return current_pp100k
+
+    def get_last_setpoint(self):
+        current_ppm = self.current * self.current_write_factor
+        return current_ppm
+
+    def set_current(self, current_ppm):
+        current = current_ppm / self.current_write_factor
+        print("\n\ncurrent {} | factor {} | scaled {}\n".format(current_ppm, self.current_write_factor, current))
+        self.current = current
+
+    def get_voltage(self):
+        return self.voltage * self.voltage_read_factor
 
     def _get_state_handlers(self):
         """

--- a/lewis_emulators/danfysik/device.py
+++ b/lewis_emulators/danfysik/device.py
@@ -96,25 +96,51 @@ class SimulatedDanfysik(StateMachineDevice):
         self._initialize_data()
 
     def set_current_read_factor(self, factor):
+        """
+        Set the scale factor between current and raw when reading a value.
+        Args:
+            factor: The scale factor to apply.
+        """
         self.current_read_factor = factor
 
     def set_current_write_factor(self, factor):
+        """
+        Set the scale factor between current and raw when writing a value.
+        Args:
+            factor: The scale factor to apply.
+        """
         self.current_write_factor = factor
 
     def get_current(self):
-        current_pp100k = self.current / self.current_read_factor
-        return current_pp100k
+        """
+        Return:
+             The readback value of current as raw value (parts per 100,000)
+        """
+        raw_rbv = self.current / self.current_read_factor
+        return raw_rbv
 
     def get_last_setpoint(self):
-        current_ppm = self.current * self.current_write_factor
-        return current_ppm
+        """
+        Return:
+             The setpoint readback value of current as raw value (parts per 1,000,000)
+        """
+        raw_sp_rbv = self.current * self.current_write_factor
+        return raw_sp_rbv
 
-    def set_current(self, current_ppm):
-        current = current_ppm / self.current_write_factor
-        print("\n\ncurrent {} | factor {} | scaled {}\n".format(current_ppm, self.current_write_factor, current))
+    def set_current(self, raw_sp):
+        """
+        Set a new value for current.
+        Args:
+            raw_sp: The new value in raw (parts per 1,000,000)
+        """
+        current = raw_sp / self.current_write_factor
         self.current = current
 
     def get_voltage(self):
+        """
+        Return:
+             The readback value of voltage scaled by the custom scale factor
+        """
         return self.voltage * self.voltage_read_factor
 
     def _get_state_handlers(self):

--- a/lewis_emulators/danfysik/interfaces/dfkps_base.py
+++ b/lewis_emulators/danfysik/interfaces/dfkps_base.py
@@ -44,8 +44,7 @@ class CommonStreamInterface(object):
     @conditional_reply("device_available")
     @conditional_reply("comms_initialized")
     def get_current(self):
-        curr = self.device.get_current()
-        return int(round(curr))
+        return int(round(self.device.get_current()))
 
     @conditional_reply("comms_initialized")
     def set_current(self, value):

--- a/lewis_emulators/danfysik/interfaces/dfkps_base.py
+++ b/lewis_emulators/danfysik/interfaces/dfkps_base.py
@@ -27,7 +27,7 @@ class CommonStreamInterface(object):
         CmdBuilder("set_power_off").escape("F").eos().build(),
         CmdBuilder("set_power_on").escape("N").eos().build(),
         CmdBuilder("get_status").escape("S1").eos().build(),
-        CmdBuilder("get_sp_rbv").escape("RA").eos().build(),
+        CmdBuilder("get_last_setpoint").escape("RA").eos().build(),
         CmdBuilder("reset").escape("RS").eos().build(),
     ]
 
@@ -44,20 +44,21 @@ class CommonStreamInterface(object):
     @conditional_reply("device_available")
     @conditional_reply("comms_initialized")
     def get_current(self):
-        return int(round(self.device.current))
+        curr = self.device.get_current()
+        return int(round(curr))
 
     @conditional_reply("comms_initialized")
     def set_current(self, value):
-        self.device.current = value
+        self.device.set_current(value)
 
     @conditional_reply("comms_initialized")
-    def get_sp_rbv(self):
-        return self.device.current
+    def get_last_setpoint(self):
+        return int(round(self.device.get_last_setpoint()))
 
     @conditional_reply("device_available")
     @conditional_reply("comms_initialized")
     def get_voltage(self):
-        return int(round(self.device.voltage))
+        return int(round(self.device.get_voltage()))
 
     @conditional_reply("comms_initialized")
     def unlock(self):


### PR DESCRIPTION
Scaling factors can now be set on an emulated Danfysik. This allows one to reproduce real device behaviour where values are read at parts per 100,000, and written at parts per 1,

Issue: https://github.com/ISISComputingGroup/IBEX/issues/5042

Related PRs: 
https://github.com/ISISComputingGroup/EPICS-IOC_Test_Framework/pull/286
https://github.com/ISISComputingGroup/EPICS-ioc/pull/465000,000.