### PR TITLE
Add emulator for DMA4500M

### DIFF
--- a/lewis_emulators/dma4500m/__init__.py
+++ b/lewis_emulators/dma4500m/__init__.py
@@ -1,0 +1,5 @@
+from .device import SimulatedDMA4500M
+from ..lewis_versions import LEWIS_LATEST
+
+framework_version = LEWIS_LATEST
+__all__ = ['SimulatedDMA4500M']

--- a/lewis_emulators/dma4500m/device.py
+++ b/lewis_emulators/dma4500m/device.py
@@ -45,7 +45,6 @@ class SimulatedDMA4500M(StateMachineDevice):
             return "measurement aborted"
 
     def finished(self):
-        print(self.status)
         return self.status
 
     def set_temperature(self, temperature):
@@ -61,7 +60,6 @@ class SimulatedDMA4500M(StateMachineDevice):
             return "no new data"
         else:
             data = self.data_buffer
-            print(data)
             self.data_buffer = ""
             return data
 

--- a/lewis_emulators/dma4500m/device.py
+++ b/lewis_emulators/dma4500m/device.py
@@ -32,17 +32,17 @@ class SimulatedDMA4500M(StateMachineDevice):
     def start(self):
         if self.measuring:
             return "measurement already started"
-
-        self.sample_id += 1
-        self.measuring = True
-        return "measurement started"
+        else:
+            self.sample_id += 1
+            self.measuring = True
+            return "measurement started"
 
     def abort(self):
         if not self.measuring:
             return "measurement not started"
-
-        self.measuring = False
-        return "measurement aborted"
+        else:
+            self.measuring = False
+            return "measurement aborted"
 
     def finished(self):
         print(self.status)
@@ -51,19 +51,19 @@ class SimulatedDMA4500M(StateMachineDevice):
     def set_temperature(self, temperature):
         if self.measuring:
             return "not allowed during measurement"
-
-        self.target_temperature = temperature
-        self.setting_temperature = True
-        return "accepted"
+        else:
+            self.target_temperature = temperature
+            self.setting_temperature = True
+            return "accepted"
 
     def get_data(self):
         if not self.data_buffer:
             return "no new data"
-
-        data = self.data_buffer
-        print(data)
-        self.data_buffer = ""
-        return data
+        else:
+            data = self.data_buffer
+            print(data)
+            self.data_buffer = ""
+            return data
 
     def get_raw_data(self):
         sample_id = self.sample_id or "NaN"

--- a/lewis_emulators/dma4500m/device.py
+++ b/lewis_emulators/dma4500m/device.py
@@ -64,7 +64,7 @@ class SimulatedDMA4500M(StateMachineDevice):
             return data
 
     def get_raw_data(self):
-        sample_id = self.sample_id or "NaN"
+        sample_id = self.sample_id if self.sample_id else "NaN"
         return "{0:.6f};{1:.2f};{2:.2f};{3}".format(self.density,
                                                     self.actual_temperature,
                                                     self.target_temperature,

--- a/lewis_emulators/dma4500m/device.py
+++ b/lewis_emulators/dma4500m/device.py
@@ -29,6 +29,49 @@ class SimulatedDMA4500M(StateMachineDevice):
     def reset(self):
         self._initialize_data()
 
+    def start(self):
+        if self.measuring:
+            return "measurement already started"
+
+        self.sample_id += 1
+        self.measuring = True
+        return "measurement started"
+
+    def abort(self):
+        if not self.measuring:
+            return "measurement not started"
+
+        self.measuring = False
+        return "measurement aborted"
+
+    def finished(self):
+        print(self.status)
+        return self.status
+
+    def set_temperature(self, temperature):
+        if self.measuring:
+            return "not allowed during measurement"
+
+        self.target_temperature = temperature
+        self.setting_temperature = True
+        return "accepted"
+
+    def get_data(self):
+        if not self.data_buffer:
+            return "no new data"
+
+        data = self.data_buffer
+        print(data)
+        self.data_buffer = ""
+        return data
+
+    def get_raw_data(self):
+        sample_id = self.sample_id or "NaN"
+        return "{0:.6f};{1:.2f};{2:.2f};{3}".format(self.density,
+                                                    self.actual_temperature,
+                                                    self.target_temperature,
+                                                    sample_id)
+
     def _get_state_handlers(self):
         return {
             "ready": states.ReadyState(),

--- a/lewis_emulators/dma4500m/device.py
+++ b/lewis_emulators/dma4500m/device.py
@@ -1,0 +1,50 @@
+from collections import OrderedDict
+
+import states
+from lewis.devices import StateMachineDevice
+
+
+class SimulatedDMA4500M(StateMachineDevice):
+
+    def _initialize_data(self):
+        """
+        Initialize all of the device's attributes.
+        """
+        self.connected = True
+        self.measurement_time = 0
+
+        self.sample_id = 0
+        self.target_temperature = 0.0
+        self.actual_temperature = 0.0
+        self.density = 0.0
+        self.condition = "valid"
+
+        self.data_buffer = ""
+        self.status = ""
+
+        self.measuring = False
+        self.last_measurement_successful = False
+        self.setting_temperature = False
+
+    def reset(self):
+        self._initialize_data()
+
+    def _get_state_handlers(self):
+        return {
+            "ready": states.ReadyState(),
+            "measuring": states.MeasuringState(),
+            "done": states.DoneState(),
+        }
+
+    def _get_initial_state(self):
+        return "ready"
+
+    def _get_transition_handlers(self):
+        return OrderedDict([
+            (("ready", "measuring"), lambda: self.measuring is True),
+            (("measuring", "ready"), lambda: self.measuring is False and not self.last_measurement_successful),
+            (("measuring", "done"), lambda: self.measuring is False and self.last_measurement_successful),
+            (("done", "measuring"), lambda: self.measuring is True),
+            (("done", "ready"), lambda: self.setting_temperature is True),
+            (("ready", "ready"), lambda: self.setting_temperature is True),
+        ])

--- a/lewis_emulators/dma4500m/interfaces/__init__.py
+++ b/lewis_emulators/dma4500m/interfaces/__init__.py
@@ -1,0 +1,3 @@
+from .stream_interface import DMA4500MStreamInterface
+
+__all__ = ['DMA4500MStreamInterface']

--- a/lewis_emulators/dma4500m/interfaces/stream_interface.py
+++ b/lewis_emulators/dma4500m/interfaces/stream_interface.py
@@ -33,25 +33,15 @@ class DMA4500MStreamInterface(StreamInterface):
 
     @if_connected
     def start(self):
-        if self._device.measuring:
-            return "measurement already started"
-
-        self._device.sample_id += 1
-        self._device.measuring = True
-        return "measurement started"
+        return self._device.start()
 
     @if_connected
     def abort(self):
-        if not self._device.measuring:
-            return "measurement not started"
-
-        self._device.measuring = False
-        return "measurement aborted"
+        return self._device.abort()
 
     @if_connected
     def finished(self):
-        print(self._device.status)
-        return self._device.status
+        return self._device.finished()
 
     @if_connected
     def set_temperature(self, temperature_arg):
@@ -60,31 +50,16 @@ class DMA4500MStreamInterface(StreamInterface):
         except ValueError:
             return "the given temperature could not be parsed"
 
-        if self._device.measuring:
-            return "not allowed during measurement"
-
-        self._device.target_temperature = temperature
-        self._device.setting_temperature = True
-        return "accepted"
+        return self._device.set_temperature(temperature)
 
     @if_connected
     def get_data(self):
-        if not self._device.data_buffer:
-            return "no new data"
-
-        data = self._device.data_buffer
-        print(data)
-        self._device.data_buffer = ""
-        return data
+        return self._device.get_data()
 
     @if_connected
     def get_data_with_subs(self):
-        return self.get_data()
+        return self._device.get_data()
 
     @if_connected
     def get_raw_data(self):
-        sample_id = self._device.sample_id or "NaN"
-        return "{0:.6f};{1:.2f};{2:.2f};{3}".format(self._device.density,
-                                                    self._device.actual_temperature,
-                                                    self._device.target_temperature,
-                                                    sample_id)
+        return self._device.get_raw_data()

--- a/lewis_emulators/dma4500m/interfaces/stream_interface.py
+++ b/lewis_emulators/dma4500m/interfaces/stream_interface.py
@@ -21,7 +21,6 @@ class DMA4500MStreamInterface(StreamInterface):
             CmdBuilder(self.finished).escape("finished").eos().build(),
             CmdBuilder(self.set_temperature).escape("set").optional(" ").escape("temperature ").arg(".+").eos().build(),
             CmdBuilder(self.get_data).escape("get").optional(" ").escape("data").eos().build(),
-            CmdBuilder(self.get_data_with_subs).escape("get").optional(" ").escape("data").optional(" ").escape("with").optional(" ").escape("subs").eos().build(),
             CmdBuilder(self.get_raw_data).escape("get").optional(" ").escape("raw").optional(" ").escape("data").eos().build(),
         }
 
@@ -54,10 +53,6 @@ class DMA4500MStreamInterface(StreamInterface):
 
     @if_connected
     def get_data(self):
-        return self._device.get_data()
-
-    @if_connected
-    def get_data_with_subs(self):
         return self._device.get_data()
 
     @if_connected

--- a/lewis_emulators/dma4500m/interfaces/stream_interface.py
+++ b/lewis_emulators/dma4500m/interfaces/stream_interface.py
@@ -1,0 +1,90 @@
+from lewis.adapters.stream import StreamInterface
+from lewis.core.logging import has_log
+from lewis_emulators.utils.command_builder import CmdBuilder
+from lewis_emulators.utils.replies import conditional_reply
+
+if_connected = conditional_reply("connected")
+
+
+@has_log
+class DMA4500MStreamInterface(StreamInterface):
+
+    in_terminator = "\r"
+    out_terminator = "\r"
+
+    # Commands that we expect via serial during normal operation
+    def __init__(self):
+        super(DMA4500MStreamInterface, self).__init__()
+        self.commands = {
+            CmdBuilder(self.start).escape("start").eos().build(),
+            CmdBuilder(self.abort).escape("abort").eos().build(),
+            CmdBuilder(self.finished).escape("finished").eos().build(),
+            CmdBuilder(self.set_temperature).escape("set").optional(" ").escape("temperature ").arg(".+").eos().build(),
+            CmdBuilder(self.get_data).escape("get").optional(" ").escape("data").eos().build(),
+            CmdBuilder(self.get_data_with_subs).escape("get").optional(" ").escape("data").optional(" ").escape("with").optional(" ").escape("subs").eos().build(),
+            CmdBuilder(self.get_raw_data).escape("get").optional(" ").escape("raw").optional(" ").escape("data").eos().build(),
+        }
+
+    def handle_error(self, request, error):
+        err_string = "command was: {}, error was: {}: {}\n".format(request, error.__class__.__name__, error)
+        print(err_string)
+        self.log.error(err_string)
+        return err_string
+
+    @if_connected
+    def start(self):
+        if self._device.measuring:
+            return "measurement already started"
+
+        self._device.sample_id += 1
+        self._device.measuring = True
+        return "measurement started"
+
+    @if_connected
+    def abort(self):
+        if not self._device.measuring:
+            return "measurement not started"
+
+        self._device.measuring = False
+        return "measurement aborted"
+
+    @if_connected
+    def finished(self):
+        print(self._device.status)
+        return self._device.status
+
+    @if_connected
+    def set_temperature(self, temperature_arg):
+        try:
+            temperature = float(temperature_arg)
+        except ValueError:
+            return "the given temperature could not be parsed"
+
+        if self._device.measuring:
+            return "not allowed during measurement"
+
+        self._device.target_temperature = temperature
+        self._device.setting_temperature = True
+        return "accepted"
+
+    @if_connected
+    def get_data(self):
+        if not self._device.data_buffer:
+            return "no new data"
+
+        data = self._device.data_buffer
+        print(data)
+        self._device.data_buffer = ""
+        return data
+
+    @if_connected
+    def get_data_with_subs(self):
+        return self.get_data()
+
+    @if_connected
+    def get_raw_data(self):
+        sample_id = self._device.sample_id or "NaN"
+        return "{0:.6f};{1:.2f};{2:.2f};{3}".format(self._device.density,
+                                                    self._device.actual_temperature,
+                                                    self._device.target_temperature,
+                                                    sample_id)

--- a/lewis_emulators/dma4500m/states.py
+++ b/lewis_emulators/dma4500m/states.py
@@ -1,0 +1,38 @@
+from lewis.core.statemachine import State
+
+
+class ReadyState(State):
+    def on_entry(self, dt):
+        self._context.status = "measurement not started"
+        self._context.actual_temperature = self._context.target_temperature
+        self._context.setting_temperature = False
+
+
+class MeasuringState(State):
+    time_elapsed = 0.0
+
+    def on_entry(self, dt):
+        self._context.status = "measurement not finished"
+        self._context.last_measurement_successful = False
+        self.time_elapsed = 0.0
+
+    def in_state(self, dt):
+        self.time_elapsed += dt
+        if self.time_elapsed > self._context.measurement_time:
+            self._context.last_measurement_successful = True
+            self._context.measuring = False
+
+    def on_exit(self, dt):
+        if not self._context.last_measurement_successful:
+            self._context.condition = "canceled"
+            self._context.data_buffer = "data: ---;---;canceled"
+        else:
+            self._context.condition = "valid"
+            self._context.data_buffer = "data: {0:.5f};{1:.2f};{2}".format(self._context.density,
+                                                                           self._context.actual_temperature,
+                                                                           self._context.condition)
+
+
+class DoneState(State):
+    def on_entry(self, dt):
+        self._context.status = "measurement finished"


### PR DESCRIPTION
### Description of work
A new emulator has been added for the Anton Paar DMA4500M density meter.

The manual at `\\ISIS\shares\ISIS_Experimental_Controls\Manuals\AntonPaar__DMA4500\XPAIB001EN_T_RefGuide_Gen_SW_Functions_M_v2.96_web` was used as a reference, combined with runnning commands on the actual device. The emulator implements all the commands used by the IOC, plus the `abort` command which I thought might be useful in the future.

Key points:
- The real device can measure many diferent quantities using user-defined methods (see its [wiki page](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/DMA4500m-Density-Meter)). The emulator assumes the default method used at ISIS, which measures density and temperature
- The device offers a `getrawdata` command to make an "instant" measurement of density and temperature. However, this is not meant to be used for actual measurements, presumably because the error bands are too large. Instead, measurements should be made by calling `start`, checking measurements progress with `finished`, then once it's complete call `getdata` to get the results
- `getdata` can only be called once. When it's called for the first time after a measurement has finished, it returns the result. Otherwise, it returns `no new data`.
- Setting the temperature with `settemperature` on the real device does not block starting a measurement and the user has no way of checking the temperature ramping progress. From the user's point of view, the only consequence of changing the temperature is that, if a measurement is started before the device is done ramping it up or down, the measurement will take longer than usual. I have not modelled this in the emulator, as it did not seem relevant

### Ticket
https://github.com/ISISComputingGroup/IBEX/issues/4948
https://github.com/ISISComputingGroup/IBEX/issues/3922

### Acceptance criteria
- The commands implemented in the emulator return the same values that they woould retuen on the actual device

