### PR TITLE
Adjust emulator from hardware

### DIFF
--- a/lewis_emulators/mezflipr/interfaces/stream_interface.py
+++ b/lewis_emulators/mezflipr/interfaces/stream_interface.py
@@ -75,7 +75,7 @@ class MezfliprStreamInterface(StreamInterface):
     @if_connected
     def set_flipper_steps(self, params):
         self._device.params = params
-        self._device.mode = "step"
+        self._device.mode = "steps"
         return "flipper_steps={}".format(params)
 
     @if_connected


### PR DESCRIPTION
The actual device uses `steps` not `step`

https://github.com/ISISComputingGroup/IBEX/issues/5313