### PR TITLE
enabled logging

### DIFF
--- a/lewis_emulators/fins/interfaces/stream_interface.py
+++ b/lewis_emulators/fins/interfaces/stream_interface.py
@@ -17,7 +17,7 @@ class FinsPLCStreamInterface(StreamInterface):
     in_terminator = ""
     out_terminator = in_terminator
 
-    do_log = False
+    do_log = True
 
     def handle_error(self, request, error):
         error_message = "An error occurred at request " + repr(request) + ": " + repr(error)


### PR DESCRIPTION
The devsim Helium Recovery FINS PLC tests were failing on the System Tests IOC debug pipeline, but only when running on NDHSPARE70. I manually run the devsim tests and they passed on NDHSPARE70. I want to enable logging in the emulator so that if the tests fail again over the weekend, I will have more information in the logs.