### PR TITLE
Fix issue with python 3 keys being iterator

### DIFF
--- a/lewis_emulators/knr1050/device.py
+++ b/lewis_emulators/knr1050/device.py
@@ -53,7 +53,7 @@ class SimulatedKnr1050(StateMachineDevice):
 
     @property
     def state_num(self):
-        return states.keys().index(self.state)
+        return list(states.keys()).index(self.state)
 
     @property
     def state(self):


### PR DESCRIPTION
Fixes knr1050 tests along with https://github.com/ISISComputingGroup/EPICS-IOC_Test_Framework/pull/415
To test:
* confirm knr1050 tests pass