### PR TITLE
Fix python 3 errors in mecfrf

### DIFF
--- a/lewis_emulators/mecfrf/interfaces/stream_interface.py
+++ b/lewis_emulators/mecfrf/interfaces/stream_interface.py
@@ -14,7 +14,7 @@ class MecfrfStreamInterface(StreamInterface):
     commands = {}
 
     in_terminator = ""
-    out_terminator = ""
+    out_terminator = b""
 
     def __init__(self):
         super(MecfrfStreamInterface, self).__init__()
@@ -49,7 +49,7 @@ class MecfrfStreamInterface(StreamInterface):
 
     def _construct_status_message(self):
         # Fixed message "preamble"
-        msg = six.binary_type("DATA")
+        msg = b"DATA"
 
         # There are 6 integer header fields which we ignore. They are:
         # - Order number


### PR DESCRIPTION
Requires https://github.com/ess-dmsc/lewis/pull/293.

To test:
* Run `%PYTHON3% -m pip uninstall lewis && %PYTHON3% -m pip install git+git://github.com/ess-dmsc/lewis@b082bf7558a0e9f59fda88c2fc03ff530644d2c2`
* Run tests and confirm they pass