### PR TITLE
Use the correct import of lewis utils

### DIFF
--- a/lewis_emulators/danfysik/interfaces/dfkps_9X00.py
+++ b/lewis_emulators/danfysik/interfaces/dfkps_9X00.py
@@ -4,8 +4,8 @@ Stream device for danfysik 9X00
 from lewis.adapters.stream import StreamInterface
 from lewis.core.logging import has_log
 
-from lewis_emulators.utils.command_builder import CmdBuilder
-from lewis_emulators.utils.replies import conditional_reply
+from lewis.utils.command_builder import CmdBuilder
+from lewis.utils.replies import conditional_reply
 from .dfkps_base import CommonStreamInterface
 
 import logging


### PR DESCRIPTION
Danfysik test was failing on not having any protocols to use, this was because of an import error in one of the stream interfaces. This PR corrects that import error