### PR TITLE
Add Tripping Functionality to Emulator

### DIFF
--- a/lewis_emulators/ttiplp/device.py
+++ b/lewis_emulators/ttiplp/device.py
@@ -18,6 +18,8 @@ class SimulatedTtiplp(StateMachineDevice):
         self.output = 0
         self.overvolt = 0
         self.overcurr = 0
+        self.ocp_tripped = False
+        self.ovp_tripped = False
 
     def reset(self):
         self._initialize_data()
@@ -50,34 +52,35 @@ class SimulatedTtiplp(StateMachineDevice):
 
     def set_volt_sp(self, volt_sp):
         self.volt_sp = float(volt_sp)
-        if float(volt_sp) > float(self.overvolt):
-            self.output = 0
-            self.volt = 0
-            self.curr = 0
+        self._check_trip()
 
     def set_curr_sp(self, curr_sp):
         self.curr_sp = float(curr_sp)
-        if float(curr_sp) > float(self.overcurr):
-            self.output = 0
-            self.volt = 0
-            self.current = 0
+        self._check_trip()
 
     def set_overvolt(self,overvolt):
         self.overvolt = float(overvolt)
-        if float(overvolt) < self.volt_sp:
-            self.volt = 0
-            self.curr = 0
-            self.output = 0
+        self._check_trip()
 
     def set_overcurr(self,overcurr):
         self.overcurr = float(overcurr)
-        if float(overcurr) < self.curr_sp:
-            self.volt = 0
-            self.curr = 0
-            self.output = 0
+        self._check_trip()
 
     def set_output(self,output):
-        if (self.volt_sp <= self.overvolt) and (self.curr_sp <= self.overcurr) and int(output) == 1:
-            self.output = 1
-        else:
-            self.output = 0
+        self.output = output
+        self._check_trip()
+
+    def is_overcurrent_tripped(self):
+        return self.ocp_tripped
+
+    def is_overvolt_tripped(self):
+        return self.ovp_tripped
+
+    def _check_trip(self):
+        if (self.output == 1):
+            if (self.volt_sp > self.overvolt):
+                self.output = 0
+                self.ovp_tripped = True
+            if(self.curr_sp > self.overcurr):
+                self.output = 0
+                self.ocp_tripped = True

--- a/lewis_emulators/ttiplp/device.py
+++ b/lewis_emulators/ttiplp/device.py
@@ -21,6 +21,8 @@ class SimulatedTtiplp(StateMachineDevice):
         self.ocp_tripped = False
         self.ovp_tripped = False
         self.hardware_tripped = False
+        self.current_limited = False
+        self.voltage_limited = False
 
     def reset(self):
         self._initialize_data()
@@ -84,11 +86,24 @@ class SimulatedTtiplp(StateMachineDevice):
         self.ovp_tripped = False
         self.ocp_tripped = False
 
+    def is_voltage_limited(self):
+        return self.voltage_limited
+
+    def is_current_limited(self):
+        return self.current_limited
+
     def _check_trip(self):
         if (self.output == 1):
+            # Trip bits
             if (self.volt_sp > self.overvolt):
                 self.output = 0
                 self.ovp_tripped = True
             if(self.curr_sp > self.overcurr):
                 self.output = 0
                 self.ocp_tripped = True
+            
+            # Limit bits
+            if(abs(self.volt_sp - self.volt) < 0.01):
+                self.voltage_limited = True
+            if(abs(self.curr_sp - self.curr) < 0.01):
+                self.current_limited = True

--- a/lewis_emulators/ttiplp/device.py
+++ b/lewis_emulators/ttiplp/device.py
@@ -20,6 +20,7 @@ class SimulatedTtiplp(StateMachineDevice):
         self.overcurr = 0
         self.ocp_tripped = False
         self.ovp_tripped = False
+        self.hardware_tripped = False
 
     def reset(self):
         self._initialize_data()
@@ -75,6 +76,9 @@ class SimulatedTtiplp(StateMachineDevice):
 
     def is_overvolt_tripped(self):
         return self.ovp_tripped
+
+    def is_hardware_tripped(self):
+        return self.hardware_tripped
 
     def reset_trip(self):
         self.ovp_tripped = False

--- a/lewis_emulators/ttiplp/device.py
+++ b/lewis_emulators/ttiplp/device.py
@@ -76,6 +76,10 @@ class SimulatedTtiplp(StateMachineDevice):
     def is_overvolt_tripped(self):
         return self.ovp_tripped
 
+    def reset_trip(self):
+        self.ovp_tripped = False
+        self.ocp_tripped = False
+
     def _check_trip(self):
         if (self.output == 1):
             if (self.volt_sp > self.overvolt):

--- a/lewis_emulators/ttiplp/interfaces/stream_interface.py
+++ b/lewis_emulators/ttiplp/interfaces/stream_interface.py
@@ -65,13 +65,13 @@ class TtiplpStreamInterface(StreamInterface):
         self.device.set_overvolt(float(overvolt))
 
     def get_overvolt(self,_):
-        return "{:.3f}".format(self.device.overvolt)
+        return "VP1 {:.3f}".format(self.device.overvolt)
 
     def set_overcurr(self, _, overcurr):
         self.device.set_overcurr(float(overcurr))
 
     def get_overcurr(self,_):
-        return "{:.4f}".format(self.device.overcurr)
+        return "CP1 {:.4f}".format(self.device.overcurr)
 
     def get_event_stat_reg(self,_):
         ret = 0

--- a/lewis_emulators/ttiplp/interfaces/stream_interface.py
+++ b/lewis_emulators/ttiplp/interfaces/stream_interface.py
@@ -75,10 +75,12 @@ class TtiplpStreamInterface(StreamInterface):
 
     def get_event_stat_reg(self,_):
         ret = 0
-        if(self.device.is_overcurrent_tripped()):
+        if(self.device.is_overcurrent_tripped()):   # Bit 2
             ret += 8
-        if(self.device.is_overvolt_tripped()):
+        if(self.device.is_overvolt_tripped()):      # Bit 3
             ret += 4
+        if(self.device.is_hardware_tripped()):      # Bit 6
+            ret += 64
         return f"{ret}"
 
     def reset_trip(self):

--- a/lewis_emulators/ttiplp/interfaces/stream_interface.py
+++ b/lewis_emulators/ttiplp/interfaces/stream_interface.py
@@ -20,6 +20,7 @@ class TtiplpStreamInterface(StreamInterface):
         CmdBuilder("set_overcurr").escape("OCP").int().escape(" ").float().eos().build(),
         CmdBuilder("get_overcurr").escape("OCP").int().escape("?").eos().build(),
         CmdBuilder("get_event_stat_reg").escape("LSR").int().escape("?").eos().build(),
+        CmdBuilder("reset_trip").escape("TRIPRST").eos().build(),
     }
     
     in_terminator = "\n"
@@ -79,3 +80,6 @@ class TtiplpStreamInterface(StreamInterface):
         if(self.device.is_overvolt_tripped()):
             ret += 4
         return f"{ret}"
+
+    def reset_trip(self):
+        self.device.reset_trip()

--- a/lewis_emulators/ttiplp/interfaces/stream_interface.py
+++ b/lewis_emulators/ttiplp/interfaces/stream_interface.py
@@ -75,10 +75,14 @@ class TtiplpStreamInterface(StreamInterface):
 
     def get_event_stat_reg(self,_):
         ret = 0
-        if(self.device.is_overcurrent_tripped()):   # Bit 2
-            ret += 8
-        if(self.device.is_overvolt_tripped()):      # Bit 3
+        if(self.device.is_voltage_limited()):       # Bit 0
+            ret += 1
+        if(self.device.is_current_limited()):       # Bit 1
+            ret += 2
+        if(self.device.is_overvolt_tripped()):      # Bit 2
             ret += 4
+        if(self.device.is_overcurrent_tripped()):   # Bit 3
+            ret += 8
         if(self.device.is_hardware_tripped()):      # Bit 6
             ret += 64
         return f"{ret}"

--- a/lewis_emulators/ttiplp/interfaces/stream_interface.py
+++ b/lewis_emulators/ttiplp/interfaces/stream_interface.py
@@ -19,6 +19,7 @@ class TtiplpStreamInterface(StreamInterface):
         CmdBuilder("get_overvolt").escape("OVP").int().escape("?").eos().build(),
         CmdBuilder("set_overcurr").escape("OCP").int().escape(" ").float().eos().build(),
         CmdBuilder("get_overcurr").escape("OCP").int().escape("?").eos().build(),
+        CmdBuilder("get_event_stat_reg").escape("LSR").int().escape("?").eos().build(),
     }
     
     in_terminator = "\n"
@@ -70,3 +71,11 @@ class TtiplpStreamInterface(StreamInterface):
 
     def get_overcurr(self,_):
         return "{:.4f}".format(self.device.overcurr)
+
+    def get_event_stat_reg(self,_):
+        ret = 0
+        if(self.device.is_overcurrent_tripped()):
+            ret += 8
+        if(self.device.is_overvolt_tripped()):
+            ret += 4
+        return f"{ret}"


### PR DESCRIPTION
The event status register is now emulated, as is the functionality for disabling the output when the current or voltage go above their respective trip values. 

Partially Resolves ISISComputingGroup/IBEX#7213