### PR TITLE
Fix phase returning frequency in Tekafg3xxx emulator

### DIFF
--- a/lewis_emulators/tekafg3XXX/interfaces/stream_interface.py
+++ b/lewis_emulators/tekafg3XXX/interfaces/stream_interface.py
@@ -184,10 +184,10 @@ class Tekafg3XXXStreamInterface(StreamInterface):
         self._channel(channel).phase = new_phase
 
     def get_burst_status(self, channel: int) -> str:
-        return 1 if self._channel(channel).burst_status == "ON" else 0
+        return self._channel(channel).burst_status
 
     def set_burst_status(self, channel: int, new_burst_status: str):
-        self._channel(channel).burst_status = new_burst_status
+        self._channel(channel).burst_status = "ON" if new_burst_status in ["ON", "1"] else "OFF"
 
     def get_burst_mode(self, channel: int) -> str:
         return self._channel(channel).burst_mode

--- a/lewis_emulators/tekafg3XXX/interfaces/stream_interface.py
+++ b/lewis_emulators/tekafg3XXX/interfaces/stream_interface.py
@@ -178,7 +178,7 @@ class Tekafg3XXXStreamInterface(StreamInterface):
         self._channel(channel).frequency_mode = new_frequency_mode
 
     def get_phase(self, channel: int) -> float:
-        return self._channel(channel).frequency
+        return self._channel(channel).phase
 
     def set_phase(self, channel: int, new_phase: float):
         self._channel(channel).phase = new_phase


### PR DESCRIPTION
The get_phase function was actually returning the frequency value. 

Refs: ISISComputingGroup/IBEX#7352