### PR TITLE
Ticket6079 add ioc aeroflex

### DIFF
--- a/lewis_emulators/aeroflex/__init__.py
+++ b/lewis_emulators/aeroflex/__init__.py
@@ -1,0 +1,5 @@
+from .device import SimulatedAeroflex
+from ..lewis_versions import LEWIS_LATEST
+
+framework_version = LEWIS_LATEST
+__all__ = ['SimulatedAeroflex']

--- a/lewis_emulators/aeroflex/device.py
+++ b/lewis_emulators/aeroflex/device.py
@@ -1,0 +1,34 @@
+from collections import OrderedDict
+from .states import DefaultState
+from lewis.devices import StateMachineDevice
+
+class SimulatedAeroflex(StateMachineDevice):
+
+    def _initialize_data(self):
+        '''
+        Initialize all of the device's attributes.
+        '''
+        self.carrier_freq_val = 2
+        self.carrier_freq_mode = 'FIXED'
+        self.carrier_freq_inc = 2
+        self.rf_lvl_unit = 'DBM'
+        self.rf_lvl_type = 'EMF'
+        self.rf_lvl_val = 30
+        self.rf_lvl_inc = 3
+        self.rf_lvl_status = 'ON'
+        self.modulation_mode = 'PM'
+        self.connected = True
+        self.triggered = False
+        self.error = '100, I AM ERROR'
+        
+    def _get_state_handlers(self):
+        return {
+            'default': DefaultState(),
+        }
+
+    def _get_initial_state(self):
+        return 'default'
+
+    def _get_transition_handlers(self):
+        return OrderedDict([
+    ])

--- a/lewis_emulators/aeroflex/interfaces/__init__.py
+++ b/lewis_emulators/aeroflex/interfaces/__init__.py
@@ -2,4 +2,4 @@ from .aeroflex_2023A import Aeroflex2023AStreamInterface
 from .aeroflex_2030 import Aeroflex2030StreamInterface
 from .aeroflex_base import CommonStreamInterface
 
-__all__ = ['Aeroflex2023AStreamInterface', 'Aeroflex2023AStreamInterface']
+__all__ = ['Aeroflex2023AStreamInterface', 'Aeroflex2030StreamInterface']

--- a/lewis_emulators/aeroflex/interfaces/__init__.py
+++ b/lewis_emulators/aeroflex/interfaces/__init__.py
@@ -1,0 +1,5 @@
+from .aeroflex_2023A import Aeroflex2023AStreamInterface
+from .aeroflex_2030 import Aeroflex2030StreamInterface
+from .aeroflex_base import CommonStreamInterface
+
+__all__ = ['Aeroflex2023AStreamInterface', 'Aeroflex2023AStreamInterface']

--- a/lewis_emulators/aeroflex/interfaces/aeroflex_2023A.py
+++ b/lewis_emulators/aeroflex/interfaces/aeroflex_2023A.py
@@ -1,0 +1,37 @@
+from lewis.adapters.stream import StreamInterface, Cmd
+from lewis.utils.command_builder import CmdBuilder
+from lewis.core.logging import has_log
+from lewis.utils.replies import conditional_reply
+from .aeroflex_base import CommonStreamInterface
+
+__all__ = ['Aeroflex2023AStreamInterface']
+
+if_connected = conditional_reply('connected')
+
+@has_log
+class Aeroflex2023AStreamInterface(CommonStreamInterface, StreamInterface):
+    protocol = 'model2023A'
+    
+    cfrq_response = ':{}:VALUE {};INC {};MODE {}'
+    
+    commands = CommonStreamInterface.commands
+    in_terminator = CommonStreamInterface.in_terminator
+    out_terminator = CommonStreamInterface.out_terminator
+    
+    def get_carrier_freq(self):
+        return self.cfrq_response.format(CommonStreamInterface.CAR_FREQ_COMM, self._device.carrier_freq_val, self._device.carrier_freq_inc, self._device.carrier_freq_mode)
+	
+        
+    def reset(self):
+        self._device.carrier_freq_val = 0
+        self._device.rf_lvl_val = 0
+        self._device.modulation_mode = 'AM'
+        
+        return ''
+        
+    def set_modulation(self, new_modulation_mode):
+        cleaned_input = new_modulation_mode.replace('1','')
+        split_modulation_val = cleaned_input.split('m')[0]
+        self._device.modulation_mode = split_modulation_val
+        
+        return ''

--- a/lewis_emulators/aeroflex/interfaces/aeroflex_2023A.py
+++ b/lewis_emulators/aeroflex/interfaces/aeroflex_2023A.py
@@ -1,4 +1,4 @@
-from lewis.adapters.stream import StreamInterface, Cmd
+from lewis.adapters.stream import StreamInterface
 from lewis.utils.command_builder import CmdBuilder
 from lewis.core.logging import has_log
 from lewis.utils.replies import conditional_reply
@@ -12,15 +12,12 @@ if_connected = conditional_reply('connected')
 class Aeroflex2023AStreamInterface(CommonStreamInterface, StreamInterface):
     protocol = 'model2023A'
     
-    cfrq_response = ':{}:VALUE {};INC {};MODE {}'
-    
     commands = CommonStreamInterface.commands
     in_terminator = CommonStreamInterface.in_terminator
     out_terminator = CommonStreamInterface.out_terminator
     
     def get_carrier_freq(self):
-        return self.cfrq_response.format(CommonStreamInterface.CAR_FREQ_COMM, self._device.carrier_freq_val, self._device.carrier_freq_inc, self._device.carrier_freq_mode)
-	
+        return f':CFRQ:VALUE {self._device.carrier_freq_val};INC {self._device.carrier_freq_inc};MODE {self._device.carrier_freq_mode}'	
         
     def reset(self):
         self._device.carrier_freq_val = 0

--- a/lewis_emulators/aeroflex/interfaces/aeroflex_2030.py
+++ b/lewis_emulators/aeroflex/interfaces/aeroflex_2030.py
@@ -1,0 +1,43 @@
+from lewis.adapters.stream import StreamInterface, Cmd
+from lewis.utils.command_builder import CmdBuilder
+from lewis.core.logging import has_log
+from lewis.utils.replies import conditional_reply
+from .aeroflex_base import CommonStreamInterface
+
+__all__ = ["Aeroflex2030StreamInterface"]
+
+if_connected = conditional_reply('connected')
+
+@has_log
+class Aeroflex2030StreamInterface(CommonStreamInterface, StreamInterface):
+    protocol = 'model2030'
+    
+    cfrq_response = ':{}:VALUE {};INC {}'
+    
+    commands = CommonStreamInterface.commands
+    in_terminator = CommonStreamInterface.in_terminator
+    out_terminator = CommonStreamInterface.out_terminator
+    
+    def get_carrier_freq(self):
+        return self.cfrq_response.format(CommonStreamInterface.CAR_FREQ_COMM, self._device.carrier_freq_val, self._device.carrier_freq_inc)
+	
+        
+    def reset(self):
+        self._device.carrier_freq_val = 0
+        self._device.rf_lvl_val = 0
+        self._device.modulation_mode = 'AM1'
+        
+        return ''
+	
+    def set_modulation(self, new_modulation_mode):
+        cleaned_input = new_modulation_mode.replace('M','M1')
+        split_modulation_val = cleaned_input.split('m')[0]
+        
+        if 'PULSE' in split_modulation_val:
+            self._device.modulation_mode = 'PULSE,' + split_modulation_val[:3]
+        else:
+            self._device.modulation_mode = split_modulation_val
+            
+        self.log.error(split_modulation_val)
+        
+        return ''

--- a/lewis_emulators/aeroflex/interfaces/aeroflex_2030.py
+++ b/lewis_emulators/aeroflex/interfaces/aeroflex_2030.py
@@ -1,4 +1,4 @@
-from lewis.adapters.stream import StreamInterface, Cmd
+from lewis.adapters.stream import StreamInterface
 from lewis.utils.command_builder import CmdBuilder
 from lewis.core.logging import has_log
 from lewis.utils.replies import conditional_reply
@@ -12,15 +12,12 @@ if_connected = conditional_reply('connected')
 class Aeroflex2030StreamInterface(CommonStreamInterface, StreamInterface):
     protocol = 'model2030'
     
-    cfrq_response = ':{}:VALUE {};INC {}'
-    
     commands = CommonStreamInterface.commands
     in_terminator = CommonStreamInterface.in_terminator
     out_terminator = CommonStreamInterface.out_terminator
     
     def get_carrier_freq(self):
-        return self.cfrq_response.format(CommonStreamInterface.CAR_FREQ_COMM, self._device.carrier_freq_val, self._device.carrier_freq_inc)
-	
+        return f':CFRQ:VALUE {self._device.carrier_freq_val};INC {self._device.carrier_freq_inc}'
         
     def reset(self):
         self._device.carrier_freq_val = 0
@@ -37,7 +34,5 @@ class Aeroflex2030StreamInterface(CommonStreamInterface, StreamInterface):
             self._device.modulation_mode = 'PULSE,' + split_modulation_val[:3]
         else:
             self._device.modulation_mode = split_modulation_val
-            
-        self.log.error(split_modulation_val)
         
         return ''

--- a/lewis_emulators/aeroflex/interfaces/aeroflex_base.py
+++ b/lewis_emulators/aeroflex/interfaces/aeroflex_base.py
@@ -1,4 +1,3 @@
-from lewis.adapters.stream import StreamInterface, Cmd
 from lewis.utils.command_builder import CmdBuilder
 from lewis.core.logging import has_log
 from lewis.utils.replies import conditional_reply
@@ -6,7 +5,7 @@ from lewis.utils.replies import conditional_reply
 if_connected = conditional_reply('connected')
 
 '''
-Stream device for danfysik
+Stream device for Aeroflex
 '''
 
 @has_log
@@ -14,15 +13,6 @@ class CommonStreamInterface(object):
 
     in_terminator = '\n'
     out_terminator = '\n'
-    
-    rflv_response = ':{}:UNITS {};TYPE {};VALUE {};INC {};{} '
-    mode_response = ':{} {}'
-    
-    CAR_FREQ_COMM = 'CFRQ'
-    RF_LVL_COMM = 'RFLV'
-    MODE_COMM = 'MODE'
-    RESET_COMM = '*RST'
-    ERROR_COMM = 'ERROR'
 
     MULT_FACTOR = {
         'k': 1000,
@@ -31,15 +21,15 @@ class CommonStreamInterface(object):
     }
     
     commands = [
-            CmdBuilder('get_carrier_freq').escape(CAR_FREQ_COMM.lower() + '?').eos().build(),
-            CmdBuilder('get_rf_level').escape(RF_LVL_COMM.lower() + '?').eos().build(),
-            CmdBuilder('get_modulation').escape(MODE_COMM.lower() + '?').eos().build(),
-            CmdBuilder('reset').escape(RESET_COMM).eos().build(),
-            CmdBuilder('get_error').escape(ERROR_COMM.lower() + '?').eos().build(),
+            CmdBuilder('get_carrier_freq').escape('cfrq?').eos().build(),
+            CmdBuilder('get_rf_level').escape('rflv?').eos().build(),
+            CmdBuilder('get_modulation').escape('mode?').eos().build(),
+            CmdBuilder('reset').escape('*RST').eos().build(),
+            CmdBuilder('get_error').escape('error?').eos().build(),
             
-            CmdBuilder('set_carrier_freq').escape(CAR_FREQ_COMM + ':VALUE ').any().eos().build(),
-            CmdBuilder('set_rf_level').escape(RF_LVL_COMM + ':VALUE ').float().eos().build(),
-            CmdBuilder('set_modulation').escape(MODE_COMM + ' ').string().eos().build(), 
+            CmdBuilder('set_carrier_freq').escape('CFRQ:VALUE ').any().eos().build(),
+            CmdBuilder('set_rf_level').escape('RFLV:VALUE ').float().eos().build(),
+            CmdBuilder('set_modulation').escape('MODE ').string().eos().build(), 
     ]
         
     def handle_error(self, request, error):
@@ -56,10 +46,10 @@ class CommonStreamInterface(object):
         return ''
     
     def get_rf_level(self):
-        return self.rflv_response.format(self.RF_LVL_COMM, self._device.rf_lvl_unit, self._device.rf_lvl_type, self._device.rf_lvl_val, self._device.rf_lvl_inc, self._device.rf_lvl_status)
+        return f':RFLV:UNITS {self._device.rf_lvl_unit};TYPE {self._device.rf_lvl_type};VALUE {self._device.rf_lvl_val};INC {self._device.rf_lvl_inc};{self._device.rf_lvl_status} '
 	
     def get_modulation(self):
-        return self.mode_response.format(self.MODE_COMM, self._device.modulation_mode)
+        return f':MODE {self._device.modulation_mode}'
         
     def get_error(self):
         return self._device.error
@@ -69,7 +59,7 @@ class CommonStreamInterface(object):
 
         if new_carrier_freq_val[-1:].isnumeric():
             self._device.carrier_freq_val = float(new_carrier_freq_val)
-        else: 
+        else:
             self._device.carrier_freq_val = float(new_carrier_freq_val[:-1]) * self.MULT_FACTOR[new_carrier_freq_val[-1:]]
         
         return ''

--- a/lewis_emulators/aeroflex/interfaces/aeroflex_base.py
+++ b/lewis_emulators/aeroflex/interfaces/aeroflex_base.py
@@ -1,0 +1,80 @@
+from lewis.adapters.stream import StreamInterface, Cmd
+from lewis.utils.command_builder import CmdBuilder
+from lewis.core.logging import has_log
+from lewis.utils.replies import conditional_reply
+
+if_connected = conditional_reply('connected')
+
+'''
+Stream device for danfysik
+'''
+
+@has_log
+class CommonStreamInterface(object):
+
+    in_terminator = '\n'
+    out_terminator = '\n'
+    
+    rflv_response = ':{}:UNITS {};TYPE {};VALUE {};INC {};{} '
+    mode_response = ':{} {}'
+    
+    CAR_FREQ_COMM = 'CFRQ'
+    RF_LVL_COMM = 'RFLV'
+    MODE_COMM = 'MODE'
+    RESET_COMM = '*RST'
+    ERROR_COMM = 'ERROR'
+
+    MULT_FACTOR = {
+        'k': 1000,
+        'M': 1000000,
+        'G': 1000000000
+    }
+    
+    commands = [
+            CmdBuilder('get_carrier_freq').escape(CAR_FREQ_COMM.lower() + '?').eos().build(),
+            CmdBuilder('get_rf_level').escape(RF_LVL_COMM.lower() + '?').eos().build(),
+            CmdBuilder('get_modulation').escape(MODE_COMM.lower() + '?').eos().build(),
+            CmdBuilder('reset').escape(RESET_COMM).eos().build(),
+            CmdBuilder('get_error').escape(ERROR_COMM.lower() + '?').eos().build(),
+            
+            CmdBuilder('set_carrier_freq').escape(CAR_FREQ_COMM + ':VALUE ').any().eos().build(),
+            CmdBuilder('set_rf_level').escape(RF_LVL_COMM + ':VALUE ').float().eos().build(),
+            CmdBuilder('set_modulation').escape(MODE_COMM + ' ').string().eos().build(), 
+    ]
+        
+    def handle_error(self, request, error):
+        '''
+        If command is not recognised print and error
+
+        Args:
+            request: requested string
+            error: problem
+
+        '''
+        self.log.error('An error occurred at request ' + repr(request) + ': ' + repr(error))
+        
+        return ''
+    
+    def get_rf_level(self):
+        return self.rflv_response.format(self.RF_LVL_COMM, self._device.rf_lvl_unit, self._device.rf_lvl_type, self._device.rf_lvl_val, self._device.rf_lvl_inc, self._device.rf_lvl_status)
+	
+    def get_modulation(self):
+        return self.mode_response.format(self.MODE_COMM, self._device.modulation_mode)
+        
+    def get_error(self):
+        return self._device.error
+        
+    def set_carrier_freq(self, new_carrier_freq):
+        new_carrier_freq_val = new_carrier_freq.split('H')[0]
+
+        if new_carrier_freq_val[-1:].isnumeric():
+            self._device.carrier_freq_val = float(new_carrier_freq_val)
+        else: 
+            self._device.carrier_freq_val = float(new_carrier_freq_val[:-1]) * self.MULT_FACTOR[new_carrier_freq_val[-1:]]
+        
+        return ''
+	
+    def set_rf_level(self, new_rf_lvl_val):
+        self._device.rf_lvl_val = new_rf_lvl_val
+        
+        return ''

--- a/lewis_emulators/aeroflex/states.py
+++ b/lewis_emulators/aeroflex/states.py
@@ -1,0 +1,5 @@
+from lewis.core.statemachine import State
+
+
+class DefaultState(State):
+    pass


### PR DESCRIPTION
Adds emulator for Aeroflex signal generator models 2023A and 2030. Emulator adheres to the devices' manuals but only implements the functionality used by the OPI required for the ticket. Similar in design to the Danfisyks emulator to allow for device switching.

https://github.com/ISISComputingGroup/IBEX/issues/6079