### PR TITLE
Remove usage of six

### DIFF
--- a/lewis_emulators/danfysik/interfaces/dfkps_base.py
+++ b/lewis_emulators/danfysik/interfaces/dfkps_base.py
@@ -2,7 +2,6 @@
 Stream device for danfysik
 """
 import abc
-import six
 
 from lewis.core.logging import has_log
 from lewis.utils.command_builder import CmdBuilder
@@ -11,8 +10,7 @@ from lewis.utils.replies import conditional_reply
 
 
 @has_log
-@six.add_metaclass(abc.ABCMeta)
-class CommonStreamInterface(object):
+class CommonStreamInterface(object, metaclass=abc.ABCMeta):
     """
     Common part of the stream interface for a Danfysik.
     """

--- a/lewis_emulators/ips/interfaces/stream_interface.py
+++ b/lewis_emulators/ips/interfaces/stream_interface.py
@@ -6,8 +6,6 @@ from lewis.utils.command_builder import CmdBuilder
 from lewis_emulators.ips.modes import Activity, Control
 from ..device import amps_to_tesla, tesla_to_amps
 
-from six import iteritems
-
 MODE_MAPPING = {
     0: Activity.HOLD,
     1: Activity.TO_SETPOINT,
@@ -95,7 +93,7 @@ class IpsStreamInterface(StreamInterface):
         resp = "X{x1}{x2}A{a}C{c}H{h}M{m1}{m2}P{p1}{p2}"
 
         def translate_activity():
-            for k, v in iteritems(MODE_MAPPING):
+            for k, v in MODE_MAPPING.items():
                 if v == self.device.activity:
                     return k
             else:

--- a/lewis_emulators/kepco/interfaces/kepco.py
+++ b/lewis_emulators/kepco/interfaces/kepco.py
@@ -1,4 +1,4 @@
-import six
+from functools import wraps
 from lewis.utils.command_builder import CmdBuilder
 from lewis.core.logging import has_log
 from lewis.adapters.stream import StreamInterface
@@ -9,7 +9,7 @@ if_connected = conditional_reply("connected")
 
 
 def needs_remote_mode(func):
-    @six.wraps(func)
+    wraps(func)
     def _wrapper(self, *args, **kwargs):
         if not self._device.remote_comms_enabled:
             raise ValueError("Not in remote mode")

--- a/lewis_emulators/kynctm3k/device.py
+++ b/lewis_emulators/kynctm3k/device.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+from functools import wraps
 
 from .states import DefaultState
 from lewis.devices import StateMachineDevice
@@ -6,7 +7,6 @@ from lewis.core.logging import has_log
 
 import random
 
-import six
 
 
 def truncate_if_set(f):
@@ -15,7 +15,7 @@ def truncate_if_set(f):
 
     """
 
-    @six.wraps(f)
+    @wraps(f)
     def wrapper(self, *args, **kwargs):
         output = f(self, *args, **kwargs)
 
@@ -33,7 +33,7 @@ def fake_auto_send(f):
 
     """
 
-    @six.wraps(f)
+    @wraps(f)
     def wrapper(self, *args, **kwargs):
         output = f(self, *args, **kwargs)
 

--- a/lewis_emulators/mecfrf/interfaces/stream_interface.py
+++ b/lewis_emulators/mecfrf/interfaces/stream_interface.py
@@ -1,4 +1,3 @@
-import six
 from lewis.adapters.stream import StreamInterface, Cmd
 import threading
 import struct

--- a/lewis_emulators/mkspr4kb/interfaces/stream_interface.py
+++ b/lewis_emulators/mkspr4kb/interfaces/stream_interface.py
@@ -1,4 +1,3 @@
-import six
 from lewis.adapters.stream import StreamInterface
 from lewis.utils.command_builder import CmdBuilder
 from lewis.utils.replies import conditional_reply
@@ -54,7 +53,7 @@ class MKS_PR4000B_StreamInterface(StreamInterface):
 
         getter_factory, setter_factory = self._get_getter_and_setter_factories()
 
-        for command_name, emulator_name in six.iteritems(numeric_get_and_set_commands):
+        for command_name, emulator_name in numeric_get_and_set_commands.items():
             self.commands.update({
                 CmdBuilder(setter_factory(emulator_name)).escape(command_name).int().escape(",").float().eos().build(),
                 CmdBuilder(getter_factory(emulator_name)).escape("?{}".format(command_name)).int().eos().build(),

--- a/lewis_emulators/tpgx6x/interfaces/stream_interface.py
+++ b/lewis_emulators/tpgx6x/interfaces/stream_interface.py
@@ -1,5 +1,4 @@
 import abc
-import six
 from lewis.adapters.stream import StreamInterface
 from lewis.utils.command_builder import CmdBuilder
 
@@ -7,8 +6,7 @@ from lewis.utils.command_builder import CmdBuilder
 ACK = chr(6)
 
 
-@six.add_metaclass(abc.ABCMeta)
-class TpgStreamInterfaceBase(object):
+class TpgStreamInterfaceBase(object, metaclass=abc.ABCMeta):
     """
     Stream interface for the serial port for either a TPG26x or TPG36x.
     """


### PR DESCRIPTION
### Description of work

Remove all references to Six

### To test
[Ticket](https://github.com/ISISComputingGroup/IBEX/issues/8297)

### Acceptance criteria

- [x] Git grep finds no `import six`.
- [x] Tests related to affected emulators (danfysik, kepco) still pass